### PR TITLE
Add support for ValidateJWTSVID

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   format:
-    name: Execute rustfmt
+    name: Execute rustfmt and clippy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -12,23 +12,14 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
+          components: rustfmt, clippy
       - name: Execute rustfmt
         run: cargo +nightly fmt
-
-  build:
-    name: Build the library
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-      - name: Build the project
-        run: cargo build
+      - name: Execute clippy
+        run: cargo +nightly clippy
 
   test:
-    name: Execute the tests
+    name: Execute the test script
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -36,32 +27,5 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-
-      - name: Install and start SPIRE server
-        run: |
-          curl -s -N -L https://github.com/spiffe/spire/releases/download/v0.12.3/spire-0.12.3-linux-x86_64-glibc.tar.gz | tar xz &&
-          cd spire-0.12.3/ &&
-          bin/spire-server run -config conf/server/server.conf &
-
-      - name: Wait for server to start
-        run: sleep 5
-
-      - name: Start SPIRE agent with join token
-        run: |
-          bin/spire-server token generate -spiffeID spiffe://example.org/myagent > /tmp/token &&
-          cut -d ' ' -f 2 /tmp/token > /tmp/token_stripped &&
-          bin/spire-agent run -config conf/agent/agent.conf -joinToken "$(< /tmp/token_stripped)" &
-
-      - name: Wait for the agent to start
-        run: sleep 5
-
-      - name: Register the workload
-        run: bin/spire-server entry create -parentID spiffe://example.org/myagent -spiffeID spiffe://example.org/myservice -selector unix:uid:$(id -u)
-
-      - name: Wait for the registration
-        run: sleep 5
-
-      - name: Test script
-        env:
-          SPIFFE_ENDPOINT_SOCKET: unix:/tmp/agent.sock
-        run: cargo test
+      - name: Run the script
+        run: ./ci.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: Continuous Integration
+
+on: [push, pull_request]
+
+jobs:
+  format:
+    name: Execute rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+      - name: Execute rustfmt
+        run: cargo +nightly fmt
+
+  build:
+    name: Build the library
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Build the project
+        run: cargo build
+
+  test:
+    name: Execute the tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Install and start SPIRE server
+        run: |
+          curl -s -N -L https://github.com/spiffe/spire/releases/download/v0.12.3/spire-0.12.3-linux-x86_64-glibc.tar.gz | tar xz &&
+          cd spire-0.12.3/ &&
+          bin/spire-server run -config conf/server/server.conf &
+
+      - name: Wait for server to start
+        run: sleep 5
+
+      - name: Start SPIRE agent with join token
+        run: |
+          bin/spire-server token generate -spiffeID spiffe://example.org/myagent > /tmp/token &&
+          cut -d ' ' -f 2 /tmp/token > /tmp/token_stripped &&
+          bin/spire-agent run -config conf/agent/agent.conf -joinToken "$(< /tmp/token_stripped)" &
+
+      - name: Wait for the agent to start
+        run: sleep 5
+
+      - name: Register the workload
+        run: bin/spire-server entry create -parentID spiffe://example.org/myagent -spiffeID spiffe://example.org/myservice -selector unix:uid:$(id -u)
+
+      - name: Wait for the registration
+        run: sleep 5
+
+      - name: Test script
+        env:
+          SPIFFE_ENDPOINT_SOCKET: unix:/tmp/agent.sock
+        run: cargo test

--- a/ci.sh
+++ b/ci.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Continuous Integration test script
+
+set -euf -o pipefail
+
+# Install and run a SPIRE server
+curl -s -N -L https://github.com/spiffe/spire/releases/download/v0.12.3/spire-0.12.3-linux-x86_64-glibc.tar.gz | tar xz
+pushd spire-0.12.3
+bin/spire-server run -config conf/server/server.conf &
+sleep 5
+
+# Run the SPIRE agent with the joint token
+bin/spire-server token generate -spiffeID spiffe://example.org/myagent > token
+cut -d ' ' -f 2 token > token_stripped
+bin/spire-agent run -config conf/agent/agent.conf -joinToken "$(< token_stripped)" &
+sleep 5
+
+# Register the workload through UID with the SPIFFE ID "spiffe://example.org/myservice"
+bin/spire-server entry create -parentID spiffe://example.org/myagent -spiffeID spiffe://example.org/myservice -selector unix:uid:$(id -u)
+sleep 5
+popd
+
+export SPIFFE_ENDPOINT_SOCKET="unix:/tmp/agent.sock"
+RUST_BACKTRACE=1 cargo test

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,8 @@
 //! let jwt_authority: &JwtAuthority = jwt_bundle.find_jwt_authority("a_key_id").unwrap();
 //!
 //! // parse a `JwtSvid` validating the token signature with a JWT bundle source.
-//! let validated_jwt_svid = JwtSvid::parse_and_validate(&jwt_token, &jwt_bundles_set, &["service1.com"])?;
+//! let validated_jwt_svid =
+//!     JwtSvid::parse_and_validate(&jwt_token, &jwt_bundles_set, &["service1.com"])?;
 //!
 //! # Ok(())
 //! # }

--- a/src/proto/workload_grpc.rs
+++ b/src/proto/workload_grpc.rs
@@ -4,7 +4,6 @@
 // https://github.com/Manishearth/rust-clippy/issues/702
 #![allow(unknown_lints)]
 #![allow(clippy::all)]
-
 #![allow(box_pointers)]
 #![allow(dead_code)]
 #![allow(missing_docs)]
@@ -16,39 +15,84 @@
 #![allow(unused_imports)]
 #![allow(unused_results)]
 
-const METHOD_SPIFFE_WORKLOAD_API_FETCH_X509_SVID: ::grpcio::Method<super::workload::X509SVIDRequest, super::workload::X509SVIDResponse> = ::grpcio::Method {
+const METHOD_SPIFFE_WORKLOAD_API_FETCH_X509_SVID: ::grpcio::Method<
+    super::workload::X509SVIDRequest,
+    super::workload::X509SVIDResponse,
+> = ::grpcio::Method {
     ty: ::grpcio::MethodType::ServerStreaming,
     name: "/SpiffeWorkloadAPI/FetchX509SVID",
-    req_mar: ::grpcio::Marshaller { ser: ::grpcio::pb_ser, de: ::grpcio::pb_de },
-    resp_mar: ::grpcio::Marshaller { ser: ::grpcio::pb_ser, de: ::grpcio::pb_de },
+    req_mar: ::grpcio::Marshaller {
+        ser: ::grpcio::pb_ser,
+        de: ::grpcio::pb_de,
+    },
+    resp_mar: ::grpcio::Marshaller {
+        ser: ::grpcio::pb_ser,
+        de: ::grpcio::pb_de,
+    },
 };
 
-const METHOD_SPIFFE_WORKLOAD_API_FETCH_X509_BUNDLES: ::grpcio::Method<super::workload::X509BundlesRequest, super::workload::X509BundlesResponse> = ::grpcio::Method {
+const METHOD_SPIFFE_WORKLOAD_API_FETCH_X509_BUNDLES: ::grpcio::Method<
+    super::workload::X509BundlesRequest,
+    super::workload::X509BundlesResponse,
+> = ::grpcio::Method {
     ty: ::grpcio::MethodType::ServerStreaming,
     name: "/SpiffeWorkloadAPI/FetchX509Bundles",
-    req_mar: ::grpcio::Marshaller { ser: ::grpcio::pb_ser, de: ::grpcio::pb_de },
-    resp_mar: ::grpcio::Marshaller { ser: ::grpcio::pb_ser, de: ::grpcio::pb_de },
+    req_mar: ::grpcio::Marshaller {
+        ser: ::grpcio::pb_ser,
+        de: ::grpcio::pb_de,
+    },
+    resp_mar: ::grpcio::Marshaller {
+        ser: ::grpcio::pb_ser,
+        de: ::grpcio::pb_de,
+    },
 };
 
-const METHOD_SPIFFE_WORKLOAD_API_FETCH_JWTSVID: ::grpcio::Method<super::workload::JWTSVIDRequest, super::workload::JWTSVIDResponse> = ::grpcio::Method {
+const METHOD_SPIFFE_WORKLOAD_API_FETCH_JWTSVID: ::grpcio::Method<
+    super::workload::JWTSVIDRequest,
+    super::workload::JWTSVIDResponse,
+> = ::grpcio::Method {
     ty: ::grpcio::MethodType::Unary,
     name: "/SpiffeWorkloadAPI/FetchJWTSVID",
-    req_mar: ::grpcio::Marshaller { ser: ::grpcio::pb_ser, de: ::grpcio::pb_de },
-    resp_mar: ::grpcio::Marshaller { ser: ::grpcio::pb_ser, de: ::grpcio::pb_de },
+    req_mar: ::grpcio::Marshaller {
+        ser: ::grpcio::pb_ser,
+        de: ::grpcio::pb_de,
+    },
+    resp_mar: ::grpcio::Marshaller {
+        ser: ::grpcio::pb_ser,
+        de: ::grpcio::pb_de,
+    },
 };
 
-const METHOD_SPIFFE_WORKLOAD_API_FETCH_JWT_BUNDLES: ::grpcio::Method<super::workload::JWTBundlesRequest, super::workload::JWTBundlesResponse> = ::grpcio::Method {
+const METHOD_SPIFFE_WORKLOAD_API_FETCH_JWT_BUNDLES: ::grpcio::Method<
+    super::workload::JWTBundlesRequest,
+    super::workload::JWTBundlesResponse,
+> = ::grpcio::Method {
     ty: ::grpcio::MethodType::ServerStreaming,
     name: "/SpiffeWorkloadAPI/FetchJWTBundles",
-    req_mar: ::grpcio::Marshaller { ser: ::grpcio::pb_ser, de: ::grpcio::pb_de },
-    resp_mar: ::grpcio::Marshaller { ser: ::grpcio::pb_ser, de: ::grpcio::pb_de },
+    req_mar: ::grpcio::Marshaller {
+        ser: ::grpcio::pb_ser,
+        de: ::grpcio::pb_de,
+    },
+    resp_mar: ::grpcio::Marshaller {
+        ser: ::grpcio::pb_ser,
+        de: ::grpcio::pb_de,
+    },
 };
 
-const METHOD_SPIFFE_WORKLOAD_API_VALIDATE_JWTSVID: ::grpcio::Method<super::workload::ValidateJWTSVIDRequest, super::workload::ValidateJWTSVIDResponse> = ::grpcio::Method {
+const METHOD_SPIFFE_WORKLOAD_API_VALIDATE_JWTSVID: ::grpcio::Method<
+    super::workload::ValidateJWTSVIDRequest,
+    super::workload::ValidateJWTSVIDResponse,
+> = ::grpcio::Method {
     ty: ::grpcio::MethodType::Unary,
     name: "/SpiffeWorkloadAPI/ValidateJWTSVID",
-    req_mar: ::grpcio::Marshaller { ser: ::grpcio::pb_ser, de: ::grpcio::pb_de },
-    resp_mar: ::grpcio::Marshaller { ser: ::grpcio::pb_ser, de: ::grpcio::pb_de },
+    req_mar: ::grpcio::Marshaller {
+        ser: ::grpcio::pb_ser,
+        de: ::grpcio::pb_de,
+    },
+    resp_mar: ::grpcio::Marshaller {
+        ser: ::grpcio::pb_ser,
+        de: ::grpcio::pb_de,
+    },
 };
 
 #[derive(Clone)]
@@ -63,95 +107,192 @@ impl SpiffeWorkloadApiClient {
         }
     }
 
-    pub fn fetch_x509_svid_opt(&self, req: &super::workload::X509SVIDRequest, opt: ::grpcio::CallOption) -> ::grpcio::Result<::grpcio::ClientSStreamReceiver<super::workload::X509SVIDResponse>> {
-        self.client.server_streaming(&METHOD_SPIFFE_WORKLOAD_API_FETCH_X509_SVID, req, opt)
+    pub fn fetch_x509_svid_opt(
+        &self,
+        req: &super::workload::X509SVIDRequest,
+        opt: ::grpcio::CallOption,
+    ) -> ::grpcio::Result<::grpcio::ClientSStreamReceiver<super::workload::X509SVIDResponse>> {
+        self.client
+            .server_streaming(&METHOD_SPIFFE_WORKLOAD_API_FETCH_X509_SVID, req, opt)
     }
 
-    pub fn fetch_x509_svid(&self, req: &super::workload::X509SVIDRequest) -> ::grpcio::Result<::grpcio::ClientSStreamReceiver<super::workload::X509SVIDResponse>> {
+    pub fn fetch_x509_svid(
+        &self,
+        req: &super::workload::X509SVIDRequest,
+    ) -> ::grpcio::Result<::grpcio::ClientSStreamReceiver<super::workload::X509SVIDResponse>> {
         self.fetch_x509_svid_opt(req, ::grpcio::CallOption::default())
     }
 
-    pub fn fetch_x509_bundles_opt(&self, req: &super::workload::X509BundlesRequest, opt: ::grpcio::CallOption) -> ::grpcio::Result<::grpcio::ClientSStreamReceiver<super::workload::X509BundlesResponse>> {
-        self.client.server_streaming(&METHOD_SPIFFE_WORKLOAD_API_FETCH_X509_BUNDLES, req, opt)
+    pub fn fetch_x509_bundles_opt(
+        &self,
+        req: &super::workload::X509BundlesRequest,
+        opt: ::grpcio::CallOption,
+    ) -> ::grpcio::Result<::grpcio::ClientSStreamReceiver<super::workload::X509BundlesResponse>>
+    {
+        self.client
+            .server_streaming(&METHOD_SPIFFE_WORKLOAD_API_FETCH_X509_BUNDLES, req, opt)
     }
 
-    pub fn fetch_x509_bundles(&self, req: &super::workload::X509BundlesRequest) -> ::grpcio::Result<::grpcio::ClientSStreamReceiver<super::workload::X509BundlesResponse>> {
+    pub fn fetch_x509_bundles(
+        &self,
+        req: &super::workload::X509BundlesRequest,
+    ) -> ::grpcio::Result<::grpcio::ClientSStreamReceiver<super::workload::X509BundlesResponse>>
+    {
         self.fetch_x509_bundles_opt(req, ::grpcio::CallOption::default())
     }
 
-    pub fn fetch_jwtsvid_opt(&self, req: &super::workload::JWTSVIDRequest, opt: ::grpcio::CallOption) -> ::grpcio::Result<super::workload::JWTSVIDResponse> {
-        self.client.unary_call(&METHOD_SPIFFE_WORKLOAD_API_FETCH_JWTSVID, req, opt)
+    pub fn fetch_jwtsvid_opt(
+        &self,
+        req: &super::workload::JWTSVIDRequest,
+        opt: ::grpcio::CallOption,
+    ) -> ::grpcio::Result<super::workload::JWTSVIDResponse> {
+        self.client
+            .unary_call(&METHOD_SPIFFE_WORKLOAD_API_FETCH_JWTSVID, req, opt)
     }
 
-    pub fn fetch_jwtsvid(&self, req: &super::workload::JWTSVIDRequest) -> ::grpcio::Result<super::workload::JWTSVIDResponse> {
+    pub fn fetch_jwtsvid(
+        &self,
+        req: &super::workload::JWTSVIDRequest,
+    ) -> ::grpcio::Result<super::workload::JWTSVIDResponse> {
         self.fetch_jwtsvid_opt(req, ::grpcio::CallOption::default())
     }
 
-    pub fn fetch_jwtsvid_async_opt(&self, req: &super::workload::JWTSVIDRequest, opt: ::grpcio::CallOption) -> ::grpcio::Result<::grpcio::ClientUnaryReceiver<super::workload::JWTSVIDResponse>> {
-        self.client.unary_call_async(&METHOD_SPIFFE_WORKLOAD_API_FETCH_JWTSVID, req, opt)
+    pub fn fetch_jwtsvid_async_opt(
+        &self,
+        req: &super::workload::JWTSVIDRequest,
+        opt: ::grpcio::CallOption,
+    ) -> ::grpcio::Result<::grpcio::ClientUnaryReceiver<super::workload::JWTSVIDResponse>> {
+        self.client
+            .unary_call_async(&METHOD_SPIFFE_WORKLOAD_API_FETCH_JWTSVID, req, opt)
     }
 
-    pub fn fetch_jwtsvid_async(&self, req: &super::workload::JWTSVIDRequest) -> ::grpcio::Result<::grpcio::ClientUnaryReceiver<super::workload::JWTSVIDResponse>> {
+    pub fn fetch_jwtsvid_async(
+        &self,
+        req: &super::workload::JWTSVIDRequest,
+    ) -> ::grpcio::Result<::grpcio::ClientUnaryReceiver<super::workload::JWTSVIDResponse>> {
         self.fetch_jwtsvid_async_opt(req, ::grpcio::CallOption::default())
     }
 
-    pub fn fetch_jwt_bundles_opt(&self, req: &super::workload::JWTBundlesRequest, opt: ::grpcio::CallOption) -> ::grpcio::Result<::grpcio::ClientSStreamReceiver<super::workload::JWTBundlesResponse>> {
-        self.client.server_streaming(&METHOD_SPIFFE_WORKLOAD_API_FETCH_JWT_BUNDLES, req, opt)
+    pub fn fetch_jwt_bundles_opt(
+        &self,
+        req: &super::workload::JWTBundlesRequest,
+        opt: ::grpcio::CallOption,
+    ) -> ::grpcio::Result<::grpcio::ClientSStreamReceiver<super::workload::JWTBundlesResponse>>
+    {
+        self.client
+            .server_streaming(&METHOD_SPIFFE_WORKLOAD_API_FETCH_JWT_BUNDLES, req, opt)
     }
 
-    pub fn fetch_jwt_bundles(&self, req: &super::workload::JWTBundlesRequest) -> ::grpcio::Result<::grpcio::ClientSStreamReceiver<super::workload::JWTBundlesResponse>> {
+    pub fn fetch_jwt_bundles(
+        &self,
+        req: &super::workload::JWTBundlesRequest,
+    ) -> ::grpcio::Result<::grpcio::ClientSStreamReceiver<super::workload::JWTBundlesResponse>>
+    {
         self.fetch_jwt_bundles_opt(req, ::grpcio::CallOption::default())
     }
 
-    pub fn validate_jwtsvid_opt(&self, req: &super::workload::ValidateJWTSVIDRequest, opt: ::grpcio::CallOption) -> ::grpcio::Result<super::workload::ValidateJWTSVIDResponse> {
-        self.client.unary_call(&METHOD_SPIFFE_WORKLOAD_API_VALIDATE_JWTSVID, req, opt)
+    pub fn validate_jwtsvid_opt(
+        &self,
+        req: &super::workload::ValidateJWTSVIDRequest,
+        opt: ::grpcio::CallOption,
+    ) -> ::grpcio::Result<super::workload::ValidateJWTSVIDResponse> {
+        self.client
+            .unary_call(&METHOD_SPIFFE_WORKLOAD_API_VALIDATE_JWTSVID, req, opt)
     }
 
-    pub fn validate_jwtsvid(&self, req: &super::workload::ValidateJWTSVIDRequest) -> ::grpcio::Result<super::workload::ValidateJWTSVIDResponse> {
+    pub fn validate_jwtsvid(
+        &self,
+        req: &super::workload::ValidateJWTSVIDRequest,
+    ) -> ::grpcio::Result<super::workload::ValidateJWTSVIDResponse> {
         self.validate_jwtsvid_opt(req, ::grpcio::CallOption::default())
     }
 
-    pub fn validate_jwtsvid_async_opt(&self, req: &super::workload::ValidateJWTSVIDRequest, opt: ::grpcio::CallOption) -> ::grpcio::Result<::grpcio::ClientUnaryReceiver<super::workload::ValidateJWTSVIDResponse>> {
-        self.client.unary_call_async(&METHOD_SPIFFE_WORKLOAD_API_VALIDATE_JWTSVID, req, opt)
+    pub fn validate_jwtsvid_async_opt(
+        &self,
+        req: &super::workload::ValidateJWTSVIDRequest,
+        opt: ::grpcio::CallOption,
+    ) -> ::grpcio::Result<::grpcio::ClientUnaryReceiver<super::workload::ValidateJWTSVIDResponse>>
+    {
+        self.client
+            .unary_call_async(&METHOD_SPIFFE_WORKLOAD_API_VALIDATE_JWTSVID, req, opt)
     }
 
-    pub fn validate_jwtsvid_async(&self, req: &super::workload::ValidateJWTSVIDRequest) -> ::grpcio::Result<::grpcio::ClientUnaryReceiver<super::workload::ValidateJWTSVIDResponse>> {
+    pub fn validate_jwtsvid_async(
+        &self,
+        req: &super::workload::ValidateJWTSVIDRequest,
+    ) -> ::grpcio::Result<::grpcio::ClientUnaryReceiver<super::workload::ValidateJWTSVIDResponse>>
+    {
         self.validate_jwtsvid_async_opt(req, ::grpcio::CallOption::default())
     }
-    pub fn spawn<F>(&self, f: F) where F: ::futures::Future<Output = ()> + Send + 'static {
+    pub fn spawn<F>(&self, f: F)
+    where
+        F: ::futures::Future<Output = ()> + Send + 'static,
+    {
         self.client.spawn(f)
     }
 }
 
 pub trait SpiffeWorkloadApi {
-    fn fetch_x509_svid(&mut self, ctx: ::grpcio::RpcContext, req: super::workload::X509SVIDRequest, sink: ::grpcio::ServerStreamingSink<super::workload::X509SVIDResponse>);
-    fn fetch_x509_bundles(&mut self, ctx: ::grpcio::RpcContext, req: super::workload::X509BundlesRequest, sink: ::grpcio::ServerStreamingSink<super::workload::X509BundlesResponse>);
-    fn fetch_jwtsvid(&mut self, ctx: ::grpcio::RpcContext, req: super::workload::JWTSVIDRequest, sink: ::grpcio::UnarySink<super::workload::JWTSVIDResponse>);
-    fn fetch_jwt_bundles(&mut self, ctx: ::grpcio::RpcContext, req: super::workload::JWTBundlesRequest, sink: ::grpcio::ServerStreamingSink<super::workload::JWTBundlesResponse>);
-    fn validate_jwtsvid(&mut self, ctx: ::grpcio::RpcContext, req: super::workload::ValidateJWTSVIDRequest, sink: ::grpcio::UnarySink<super::workload::ValidateJWTSVIDResponse>);
+    fn fetch_x509_svid(
+        &mut self,
+        ctx: ::grpcio::RpcContext,
+        req: super::workload::X509SVIDRequest,
+        sink: ::grpcio::ServerStreamingSink<super::workload::X509SVIDResponse>,
+    );
+    fn fetch_x509_bundles(
+        &mut self,
+        ctx: ::grpcio::RpcContext,
+        req: super::workload::X509BundlesRequest,
+        sink: ::grpcio::ServerStreamingSink<super::workload::X509BundlesResponse>,
+    );
+    fn fetch_jwtsvid(
+        &mut self,
+        ctx: ::grpcio::RpcContext,
+        req: super::workload::JWTSVIDRequest,
+        sink: ::grpcio::UnarySink<super::workload::JWTSVIDResponse>,
+    );
+    fn fetch_jwt_bundles(
+        &mut self,
+        ctx: ::grpcio::RpcContext,
+        req: super::workload::JWTBundlesRequest,
+        sink: ::grpcio::ServerStreamingSink<super::workload::JWTBundlesResponse>,
+    );
+    fn validate_jwtsvid(
+        &mut self,
+        ctx: ::grpcio::RpcContext,
+        req: super::workload::ValidateJWTSVIDRequest,
+        sink: ::grpcio::UnarySink<super::workload::ValidateJWTSVIDResponse>,
+    );
 }
 
-pub fn create_spiffe_workload_api<S: SpiffeWorkloadApi + Send + Clone + 'static>(s: S) -> ::grpcio::Service {
+pub fn create_spiffe_workload_api<S: SpiffeWorkloadApi + Send + Clone + 'static>(
+    s: S,
+) -> ::grpcio::Service {
     let mut builder = ::grpcio::ServiceBuilder::new();
     let mut instance = s.clone();
-    builder = builder.add_server_streaming_handler(&METHOD_SPIFFE_WORKLOAD_API_FETCH_X509_SVID, move |ctx, req, resp| {
-        instance.fetch_x509_svid(ctx, req, resp)
-    });
+    builder = builder.add_server_streaming_handler(
+        &METHOD_SPIFFE_WORKLOAD_API_FETCH_X509_SVID,
+        move |ctx, req, resp| instance.fetch_x509_svid(ctx, req, resp),
+    );
     let mut instance = s.clone();
-    builder = builder.add_server_streaming_handler(&METHOD_SPIFFE_WORKLOAD_API_FETCH_X509_BUNDLES, move |ctx, req, resp| {
-        instance.fetch_x509_bundles(ctx, req, resp)
-    });
+    builder = builder.add_server_streaming_handler(
+        &METHOD_SPIFFE_WORKLOAD_API_FETCH_X509_BUNDLES,
+        move |ctx, req, resp| instance.fetch_x509_bundles(ctx, req, resp),
+    );
     let mut instance = s.clone();
-    builder = builder.add_unary_handler(&METHOD_SPIFFE_WORKLOAD_API_FETCH_JWTSVID, move |ctx, req, resp| {
-        instance.fetch_jwtsvid(ctx, req, resp)
-    });
+    builder = builder.add_unary_handler(
+        &METHOD_SPIFFE_WORKLOAD_API_FETCH_JWTSVID,
+        move |ctx, req, resp| instance.fetch_jwtsvid(ctx, req, resp),
+    );
     let mut instance = s.clone();
-    builder = builder.add_server_streaming_handler(&METHOD_SPIFFE_WORKLOAD_API_FETCH_JWT_BUNDLES, move |ctx, req, resp| {
-        instance.fetch_jwt_bundles(ctx, req, resp)
-    });
+    builder = builder.add_server_streaming_handler(
+        &METHOD_SPIFFE_WORKLOAD_API_FETCH_JWT_BUNDLES,
+        move |ctx, req, resp| instance.fetch_jwt_bundles(ctx, req, resp),
+    );
     let mut instance = s;
-    builder = builder.add_unary_handler(&METHOD_SPIFFE_WORKLOAD_API_VALIDATE_JWTSVID, move |ctx, req, resp| {
-        instance.validate_jwtsvid(ctx, req, resp)
-    });
+    builder = builder.add_unary_handler(
+        &METHOD_SPIFFE_WORKLOAD_API_VALIDATE_JWTSVID,
+        move |ctx, req, resp| instance.validate_jwtsvid(ctx, req, resp),
+    );
     builder.build()
 }

--- a/src/svid/jwt/mod.rs
+++ b/src/svid/jwt/mod.rs
@@ -1,7 +1,7 @@
 //! JWT SVID types.
 
-use std::str::FromStr;
 use std::convert::TryFrom;
+use std::str::FromStr;
 
 use chrono::{DateTime, TimeZone, Utc};
 use jsonwebtoken::{dangerous_insecure_decode, Algorithm};
@@ -144,9 +144,23 @@ impl TryFrom<protobuf::well_known_types::Struct> for Claims {
     fn try_from(claims: protobuf::well_known_types::Struct) -> Result<Self, Self::Error> {
         let fields = claims.fields;
         Ok(Claims {
-            sub: fields.get("sub").ok_or_else(|| JwtSvidError::RequiredClaimMissing("sub".to_string()))?.get_string_value().to_string(),
-            aud: fields.get("aud").ok_or_else(|| JwtSvidError::RequiredClaimMissing("aud".to_string()))?.get_list_value().values.iter().map(|v| v.get_string_value().to_string()).collect(),
-            exp: fields.get("exp").ok_or_else(|| JwtSvidError::RequiredClaimMissing("exp".to_string()))?.get_number_value() as u32,
+            sub: fields
+                .get("sub")
+                .ok_or_else(|| JwtSvidError::RequiredClaimMissing("sub".to_string()))?
+                .get_string_value()
+                .to_string(),
+            aud: fields
+                .get("aud")
+                .ok_or_else(|| JwtSvidError::RequiredClaimMissing("aud".to_string()))?
+                .get_list_value()
+                .values
+                .iter()
+                .map(|v| v.get_string_value().to_string())
+                .collect(),
+            exp: fields
+                .get("exp")
+                .ok_or_else(|| JwtSvidError::RequiredClaimMissing("exp".to_string()))?
+                .get_number_value() as u32,
         })
     }
 }

--- a/src/svid/jwt/mod.rs
+++ b/src/svid/jwt/mod.rs
@@ -201,7 +201,7 @@ impl JwtSvid {
 
         let mut validation = jsonwebtoken::Validation::new(jwt_svid.alg.to_owned());
         validation.validate_exp = true;
-        jsonwebtoken::decode::<Claims>(&token, &jwt_authority.key.to_decoding_key(), &validation)?;
+        jsonwebtoken::decode::<Claims>(token, &jwt_authority.key.to_decoding_key(), &validation)?;
 
         JwtSvid::validate_audience(&jwt_svid, expected_audience)?;
 
@@ -278,7 +278,7 @@ impl FromStr for JwtSvid {
     /// IMPORTANT: For parsing and validating the signature of untrusted tokens, use `parse_and_validate` method.
     fn from_str(token: &str) -> Result<Self, Self::Err> {
         // decode token without signature or expiration validation
-        let token_data = dangerous_insecure_decode::<Claims>(&token)?;
+        let token_data = dangerous_insecure_decode::<Claims>(token)?;
 
         let claims = token_data.claims;
         let spiffe_id = SpiffeId::from_str(&claims.sub)?;

--- a/src/workload_api/client.rs
+++ b/src/workload_api/client.rs
@@ -322,7 +322,11 @@ impl WorkloadApiClient {
     ) -> Result<(SpiffeId, Option<Claims>), ClientError> {
         let response = self.validate_jwt(audience, jwt_token)?;
 
-        let claims = response.claims.into_option().map(|claims| claims.try_into()).transpose()?;
+        let claims = response
+            .claims
+            .into_option()
+            .map(|claims| claims.try_into())
+            .transpose()?;
 
         Ok((response.spiffe_id.try_into()?, claims))
     }

--- a/src/workload_api/mod.rs
+++ b/src/workload_api/mod.rs
@@ -3,7 +3,7 @@
 //! # Examples
 //!
 //! ```no_run
-//!
+//! 
 //! use std::error::Error;
 //! use spiffe::workload_api::client::WorkloadApiClient;
 //!

--- a/tests/workload_api_client_test.rs
+++ b/tests/workload_api_client_test.rs
@@ -1,0 +1,19 @@
+// These tests suppose a SPIFFE implementation is running.
+
+use spiffe::workload_api::client::WorkloadApiClient;
+
+#[test]
+fn fetch_jwt_svid() {
+    let client = WorkloadApiClient::default().unwrap();
+    let svid = client.fetch_jwt_svid(&["my_audience"], None).unwrap();
+    assert_eq!(svid.audience(), &["my_audience"]);
+}
+
+#[test]
+fn fetch_and_validate_jwt_token() {
+    let client = WorkloadApiClient::default().unwrap();
+    let token = client.fetch_jwt_token(&["my_audience"], None).unwrap();
+    let (spiffe_id, claims) = client.validate_jwt_token("my_audience", &token).unwrap();
+    assert_eq!(claims.unwrap().get_aud(), &["my_audience"]);
+    assert_eq!(spiffe_id.to_string(), "spiffe://example.org/myservice");
+}


### PR DESCRIPTION
This PR mainly adds the Rust wrapper around the `validate_jwtsvid_opt` Workload API call.
It also sets up GitHub Actions to perform static checks and execute tests. Also starts up a SPIRE server/agent to be able to test the client.