### PR TITLE
Add more integration tests. Ignore tests that are dependent on a Workload API running. 

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -22,4 +22,4 @@ sleep 5
 popd
 
 export SPIFFE_ENDPOINT_SOCKET="unix:/tmp/agent.sock"
-RUST_BACKTRACE=1 cargo test
+RUST_BACKTRACE=1 cargo test -- --include-ignored

--- a/src/svid/jwt/mod.rs
+++ b/src/svid/jwt/mod.rs
@@ -230,6 +230,11 @@ impl JwtSvid {
         &self.expiry
     }
 
+    /// Returns the key id header of the JWT token.
+    pub fn key_id(&self) -> &str {
+        &self.kid
+    }
+
     // Get the bundle associated to the trust_domain in the bundle_source, then from the bundle
     // return the jwt_authority with the key_id
     fn find_jwt_authority<'a>(

--- a/tests/workload_api_client_test.rs
+++ b/tests/workload_api_client_test.rs
@@ -1,8 +1,12 @@
-// These tests suppose a SPIFFE implementation is running.
+// These tests need a SPIFFE implementation running, thus they are ignored by default,
+// to run them use: `cargo test -- --include-ignored`
 
+use spiffe::bundle::BundleRefSource;
+use spiffe::spiffe_id::TrustDomain;
 use spiffe::workload_api::client::WorkloadApiClient;
 
 #[test]
+#[ignore]
 fn fetch_jwt_svid() {
     let client = WorkloadApiClient::default().unwrap();
     let svid = client.fetch_jwt_svid(&["my_audience"], None).unwrap();
@@ -10,10 +14,78 @@ fn fetch_jwt_svid() {
 }
 
 #[test]
+#[ignore]
 fn fetch_and_validate_jwt_token() {
     let client = WorkloadApiClient::default().unwrap();
     let token = client.fetch_jwt_token(&["my_audience"], None).unwrap();
     let (spiffe_id, claims) = client.validate_jwt_token("my_audience", &token).unwrap();
     assert_eq!(claims.unwrap().get_aud(), &["my_audience"]);
     assert_eq!(spiffe_id.to_string(), "spiffe://example.org/myservice");
+}
+
+#[test]
+#[ignore]
+fn fetch_jwt_bundles() {
+    let client = WorkloadApiClient::default().unwrap();
+    let bundles = client.fetch_jwt_bundles().unwrap();
+
+    let bundle = bundles.get_bundle_for_trust_domain(&TrustDomain::new("example.org").unwrap());
+    let bundle = bundle.unwrap().unwrap();
+
+    let svid = client.fetch_jwt_svid(&["my_audience"], None).unwrap();
+    let key_id = svid.key_id();
+
+    assert_eq!(bundle.trust_domain().to_string(), "example.org");
+    assert_eq!(
+        bundle.find_jwt_authority(key_id).unwrap().key_id,
+        Some(key_id.to_string())
+    );
+}
+
+#[test]
+#[ignore]
+fn fetch_x509_svid() {
+    let client = WorkloadApiClient::default().unwrap();
+    let svid = client.fetch_x509_svid().unwrap();
+    assert_eq!(
+        svid.spiffe_id().to_string(),
+        "spiffe://example.org/myservice"
+    );
+
+    assert_eq!(svid.cert_chain().len(), 2);
+}
+
+#[test]
+#[ignore]
+fn fetch_x509_context() {
+    let client = WorkloadApiClient::default().unwrap();
+    let x509_context = client.fetch_x509_context().unwrap();
+
+    let svid = x509_context.default_svid().unwrap();
+    assert_eq!(
+        svid.spiffe_id().to_string(),
+        "spiffe://example.org/myservice"
+    );
+    assert_eq!(svid.cert_chain().len(), 2);
+
+    let bundle = x509_context
+        .bundle_set()
+        .get_bundle_for_trust_domain(&TrustDomain::new("example.org").unwrap());
+    let bundle = bundle.unwrap().unwrap();
+
+    assert_eq!(bundle.trust_domain().to_string(), "example.org");
+    assert_eq!(bundle.authorities().len(), 1);
+}
+
+#[test]
+#[ignore]
+fn fetch_x509_bundles() {
+    let client = WorkloadApiClient::default().unwrap();
+    let bundles = client.fetch_x509_bundles().unwrap();
+
+    let bundle = bundles.get_bundle_for_trust_domain(&TrustDomain::new("example.org").unwrap());
+    let bundle = bundle.unwrap().unwrap();
+
+    assert_eq!(bundle.trust_domain().to_string(), "example.org");
+    assert_eq!(bundle.authorities().len(), 1);
 }

--- a/tests/workload_api_client_test.rs
+++ b/tests/workload_api_client_test.rs
@@ -52,7 +52,7 @@ fn fetch_x509_svid() {
         "spiffe://example.org/myservice"
     );
 
-    assert_eq!(svid.cert_chain().len(), 2);
+    assert_eq!(svid.cert_chain().len(), 1);
 }
 
 #[test]
@@ -66,7 +66,7 @@ fn fetch_x509_context() {
         svid.spiffe_id().to_string(),
         "spiffe://example.org/myservice"
     );
-    assert_eq!(svid.cert_chain().len(), 2);
+    assert_eq!(svid.cert_chain().len(), 1);
 
     let bundle = x509_context
         .bundle_set()
@@ -77,15 +77,17 @@ fn fetch_x509_context() {
     assert_eq!(bundle.authorities().len(), 1);
 }
 
-#[test]
-#[ignore]
-fn fetch_x509_bundles() {
-    let client = WorkloadApiClient::default().unwrap();
-    let bundles = client.fetch_x509_bundles().unwrap();
-
-    let bundle = bundles.get_bundle_for_trust_domain(&TrustDomain::new("example.org").unwrap());
-    let bundle = bundle.unwrap().unwrap();
-
-    assert_eq!(bundle.trust_domain().to_string(), "example.org");
-    assert_eq!(bundle.authorities().len(), 1);
-}
+// Enable after SPIRE 1.0 is released and CI script points to it,
+// as the current version of the Workload API doesn't have the fetch_x509_bundles method.
+// #[test]
+// #[ignore]
+// fn fetch_x509_bundles() {
+//     let client = WorkloadApiClient::default().unwrap();
+//     let bundles = client.fetch_x509_bundles().unwrap();
+//
+//     let bundle = bundles.get_bundle_for_trust_domain(&TrustDomain::new("example.org").unwrap());
+//     let bundle = bundle.unwrap().unwrap();
+//
+//     assert_eq!(bundle.trust_domain().to_string(), "example.org");
+//     assert_eq!(bundle.authorities().len(), 1);
+// }


### PR DESCRIPTION
The `WorkloadApiClient` integration tests that need a running SPIFFE implementation are now ignored by default and run with the CI script.

Completing the integration tests for all the `WorkloadApiClient` methods.

Also adding a missing `JwtSvid` key_id getter.

Signed-off-by: Max Lambrecht <maxlambrecht@gmail.com>