### PR TITLE
Strict SPIFFE ID parsing

### DIFF
--- a/src/spiffe_id/mod.rs
+++ b/src/spiffe_id/mod.rs
@@ -6,11 +6,9 @@ use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
 use thiserror::Error;
-use url::{ParseError, Url};
 
 const SPIFFE_SCHEME: &str = "spiffe";
-const SPIFFE_ID_MAXIMUM_LENGTH: usize = 2048;
-const TRUST_DOMAIN_MAXIMUM_LENGTH: usize = 255;
+const SCHEME_PREFIX: &str = "spiffe://";
 
 /// Represents a [SPIFFE ID](https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE-ID.md#2-spiffe-identity).
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
@@ -30,48 +28,45 @@ pub struct TrustDomain {
 #[non_exhaustive]
 pub enum SpiffeIdError {
     /// An empty string cannot be parsed as a SPIFFE ID.
-    #[error("SPIFFE ID cannot be empty")]
+    #[error("cannot be empty")]
     Empty,
 
-    /// A SPIFFE ID cannot be longer than 2048 characters.
-    #[error("SPIFFE ID is too long")]
-    IdTooLong,
-
-    /// A SPIFFE ID must have a scheme 'spiffe'.
-    #[error("scheme is missing")]
-    MissingScheme,
-
-    /// A SPIFFE ID must have a scheme 'spiffe'.
-    #[error("invalid scheme")]
-    InvalidScheme,
-
-    /// The host component of SPIFFE ID URI cannot be empty.
-    #[error("trust domain cannot be empty")]
+    /// The trust domain name of SPIFFE ID cannot be empty.
+    #[error("trust domain is missing")]
     MissingTrustDomain,
 
-    /// TrustDomain, i.e. host component in URI cannot be longer than 255 characters.
-    #[error("trust domain is too long")]
-    TrustDomainTooLong,
+    /// A SPIFFE ID must have a scheme 'spiffe'.
+    #[error("scheme is missing or invalid")]
+    WrongScheme,
 
-    /// A SPIFFE ID URI cannot have a port.
-    #[error("port is not allowed")]
-    PortNotAllowed,
+    /// A trust domain name can only contain chars in a limited char set.
+    #[error(
+        "trust domain characters are limited to lowercase letters, numbers, dots, dashes, and \
+         underscores"
+    )]
+    BadTrustDomainChar,
 
-    /// A SPIFFE ID URI cannot have a query.
-    #[error("query is not allowed")]
-    QueryNotAllowed,
+    /// A path segment can only contain chars in a limited char set.
+    #[error(
+        "path segment characters are limited to letters, numbers, dots, dashes, and underscores"
+    )]
+    BadPathSegmentChar,
 
-    /// A SPIFFE ID URI cannot have a fragment.
-    #[error("fragment is not allowed")]
-    FragmentNotAllowed,
+    /// Path cannot contain empty segments, e.g '//'
+    #[error("path cannot contain empty segments")]
+    EmptySegment,
 
-    /// A SPIFFE ID URI cannot have a user info.
-    #[error("user info is not allowed")]
-    UserInfoNotAllowed,
+    /// Path cannot contain dot segments, e.g '/.', '/..'
+    #[error("path cannot contain dot segments")]
+    DotSegment,
 
-    /// Error returned by the URI parsing library.
-    #[error("failed parsing SPIFFE ID from Uri")]
-    CannotParseUri(#[from] ParseError),
+    /// Path must have a leading slash.
+    #[error("path must have a leading slash")]
+    NoLeadingSlash,
+
+    /// Path cannot have a trailing slash.
+    #[error("path cannot have a trailing slash")]
+    TrailingSlash,
 }
 
 impl SpiffeId {
@@ -79,7 +74,7 @@ impl SpiffeId {
     ///
     /// # Arguments
     ///
-    /// * `id` - A SPIFFE ID, e.g. 'spiffe://example.org/path/subpath'
+    /// * `id` - A SPIFFE ID, e.g. 'spiffe://trustdomain/path/other'
     ///
     /// # Errors
     ///
@@ -90,29 +85,47 @@ impl SpiffeId {
     /// ```
     /// use spiffe::spiffe_id::SpiffeId;
     ///
-    /// let spiffe_id = SpiffeId::new("spiffe://example.org/path").unwrap();
-    /// assert_eq!("example.org", spiffe_id.trust_domain().to_string());
+    /// let spiffe_id = SpiffeId::new("spiffe://trustdomain/path").unwrap();
+    /// assert_eq!("trustdomain", spiffe_id.trust_domain().to_string());
     /// assert_eq!("/path", spiffe_id.path());
     /// ```
     pub fn new(id: &str) -> Result<Self, SpiffeIdError> {
-        let id = id.trim();
         if id.is_empty() {
             return Err(SpiffeIdError::Empty);
         }
 
-        let url = Url::from_str(id)?;
-        Self::validate_spiffe_id(&url)?;
+        if !id.contains(SCHEME_PREFIX) {
+            return Err(SpiffeIdError::WrongScheme);
+        }
 
-        let domain_name = match url.host_str() {
-            None => return Err(SpiffeIdError::MissingTrustDomain),
-            Some(host) if host.len() > TRUST_DOMAIN_MAXIMUM_LENGTH => {
-                return Err(SpiffeIdError::TrustDomainTooLong)
+        let rest = &id[SCHEME_PREFIX.len()..];
+
+        let mut i = 0;
+
+        for c in rest.chars() {
+            if c == '/' {
+                break;
             }
-            Some(host) => host.to_lowercase(),
-        };
 
-        let trust_domain = TrustDomain { name: domain_name };
-        let path = String::from(url.path());
+            if !is_valid_trust_domain_char(c) {
+                return Err(SpiffeIdError::BadTrustDomainChar);
+            }
+            i += 1;
+        }
+
+        if i == 0 {
+            return Err(SpiffeIdError::MissingTrustDomain);
+        }
+
+        let td = &rest[0..i];
+        let path = &rest[i..];
+
+        validate_path(path)?;
+
+        let trust_domain = TrustDomain {
+            name: td.to_string(),
+        };
+        let path = path.to_string();
         Ok(SpiffeId { trust_domain, path })
     }
 
@@ -129,39 +142,6 @@ impl SpiffeId {
     /// Returns `true` if this SPIFFE ID has the given TrustDomain.
     pub fn is_member_of(&self, trust_domain: &TrustDomain) -> bool {
         &self.trust_domain == trust_domain
-    }
-
-    // Performs the validations to comply with the SPIFFE standard.
-    fn validate_spiffe_id(url: &Url) -> Result<(), SpiffeIdError> {
-        if url.scheme().is_empty() {
-            return Err(SpiffeIdError::MissingScheme);
-        }
-
-        if url.scheme() != SPIFFE_SCHEME {
-            return Err(SpiffeIdError::InvalidScheme);
-        }
-
-        if url.query().is_some() {
-            return Err(SpiffeIdError::QueryNotAllowed);
-        }
-
-        if url.fragment().is_some() {
-            return Err(SpiffeIdError::FragmentNotAllowed);
-        }
-
-        if !url.username().is_empty() {
-            return Err(SpiffeIdError::UserInfoNotAllowed);
-        }
-
-        if url.port().is_some() {
-            return Err(SpiffeIdError::PortNotAllowed);
-        }
-
-        if url.as_str().len() > SPIFFE_ID_MAXIMUM_LENGTH {
-            return Err(SpiffeIdError::IdTooLong);
-        }
-
-        Ok(())
     }
 }
 
@@ -189,18 +169,65 @@ impl TryFrom<String> for SpiffeId {
 impl TryFrom<&str> for SpiffeId {
     type Error = SpiffeIdError;
     fn try_from(s: &str) -> Result<SpiffeId, Self::Error> {
-        Self::from_str(s)
+        Self::new(s)
     }
 }
 
+// Validates that a path string is a conformant path for a SPIFFE ID. Namely:
+// - does not contain an empty segments (including a trailing slash)
+// - does not contain dot segments (i.e. '.' or '..')
+// - does not contain any percent encoded characters
+// - has only characters from the unreserved or sub-delims set from RFC3986.
+fn validate_path(path: &str) -> Result<(), SpiffeIdError> {
+    if path.is_empty() {
+        return Ok(());
+    }
+
+    if (path.as_bytes()[0] as char) != '/' {
+        return Err(SpiffeIdError::NoLeadingSlash);
+    }
+
+    let mut segment_start = 0;
+    let mut segment_end = 0;
+
+    while segment_end < path.len() {
+        let c = path.as_bytes()[segment_end] as char;
+        if c == '/' {
+            match &path[segment_start..segment_end] {
+                "/" => return Err(SpiffeIdError::EmptySegment),
+                "/." | "/.." => return Err(SpiffeIdError::DotSegment),
+                _ => {}
+            }
+            segment_start = segment_end;
+            segment_end += 1;
+            continue;
+        }
+
+        if !is_valid_path_segment_char(c) {
+            return Err(SpiffeIdError::BadPathSegmentChar);
+        }
+        segment_end += 1;
+    }
+
+    match &path[segment_start..segment_end] {
+        "/" => return Err(SpiffeIdError::TrailingSlash),
+        "/." | "/.." => return Err(SpiffeIdError::DotSegment),
+        _ => {}
+    }
+
+    Ok(())
+}
+
+fn is_valid_path_segment_char(c: char) -> bool {
+    matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '.' | '_')
+}
+
 impl TrustDomain {
-    /// Attempts to parse a TrustDomain instance from the given name.
-    ///
-    /// The name is normalized to lowercase and cannot be longer than 255 characters.
+    /// Attempts to parse a TrustDomain instance from the given name or spiffe_id string.
     ///
     /// # Arguments
     ///
-    /// * `name` - Name of the trust domain, it also can be a SPIFFE ID string from which the domain name
+    /// * `id_or_name` - Name of a trust domain, it also can be a SPIFFE ID string from which the domain name
     /// is extracted.
     ///
     /// # Errors
@@ -212,7 +239,7 @@ impl TrustDomain {
     /// ```
     /// use spiffe::spiffe_id::TrustDomain;
     ///
-    /// let trust_domain = TrustDomain::new("Domain.Test").unwrap();
+    /// let trust_domain = TrustDomain::new("domain.test").unwrap();
     /// assert_eq!("domain.test", trust_domain.to_string());
     /// assert_eq!("spiffe://domain.test", trust_domain.id_string());
     ///
@@ -220,20 +247,23 @@ impl TrustDomain {
     /// assert_eq!("example.org", trust_domain.to_string());
     /// assert_eq!("spiffe://example.org", trust_domain.id_string());
     /// ```
-    pub fn new(name: &str) -> Result<Self, SpiffeIdError> {
-        let name = name.trim();
-        if name.is_empty() {
+    pub fn new(id_or_name: &str) -> Result<Self, SpiffeIdError> {
+        if id_or_name.is_empty() {
             return Err(SpiffeIdError::MissingTrustDomain);
         }
 
-        let mut name = name.to_lowercase();
-        if !name.contains("://") {
-            name = format!("{}://{}", SPIFFE_SCHEME, name);
+        // Something looks kinda like a scheme separator, let's try to parse as
+        // an ID. We use :/ instead of :// since the diagnostics are better for
+        // a bad input like spiffe:/trustdomain.
+        if id_or_name.contains(":/") {
+            let spiffe_id = SpiffeId::try_from(id_or_name)?;
+            return Ok(spiffe_id.trust_domain);
         }
 
-        let spiffe_id = SpiffeId::try_from(name)?;
-
-        Ok(spiffe_id.trust_domain)
+        validate_trust_domain_name(id_or_name)?;
+        Ok(TrustDomain {
+            name: id_or_name.to_string(),
+        })
     }
 
     /// Returns a string representation of the SPIFFE ID of the trust domain,
@@ -279,13 +309,37 @@ impl TryFrom<String> for TrustDomain {
     }
 }
 
+fn validate_trust_domain_name(name: &str) -> Result<(), SpiffeIdError> {
+    for c in name.chars() {
+        if !is_valid_trust_domain_char(c) {
+            return Err(SpiffeIdError::BadTrustDomainChar);
+        }
+    }
+    Ok(())
+}
+
+fn is_valid_trust_domain_char(c: char) -> bool {
+    matches!(c, 'a'..='z' | '0'..='9' | '-' | '.' | '_')
+}
+
 #[cfg(test)]
 mod spiffe_id_tests {
     use std::str::FromStr;
 
-    use url::ParseError;
-
     use super::*;
+
+    pub(crate) const TD_CHARS: &[char] = &[
+        'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r',
+        's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+        '.', '-', '_',
+    ];
+
+    const PATH_CHARS: &[char] = &[
+        'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r',
+        's', 't', 'u', 'v', 'w', 'x', 'y', 'z', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J',
+        'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '0', '1',
+        '2', '3', '4', '5', '6', '7', '8', '9', '.', '-', '_',
+    ];
 
     macro_rules! spiffe_id_success_tests {
         ($($name:ident: $value:expr,)*) => {
@@ -301,27 +355,18 @@ mod spiffe_id_tests {
     }
 
     spiffe_id_success_tests! {
+        from_valid_spiffe_id_str: (
+            "spiffe://trustdomain",
+            SpiffeId {
+                trust_domain: TrustDomain::from_str("trustdomain").unwrap(),
+                path: "".to_string(),
+            }
+        ),
         from_valid_uri_str: (
-            "spiffe://example.org/path/element",
+            "spiffe://trustdomain/path/element",
             SpiffeId {
-                trust_domain: TrustDomain::from_str("example.org").unwrap(),
+                trust_domain: TrustDomain::from_str("trustdomain").unwrap(),
                 path: "/path/element".to_string(),
-            }
-        ),
-
-        from_valid_uri_str_preserve_case_for_path: (
-            "spiffe://EXAMPLE.org/PATH/Element",
-            SpiffeId {
-                trust_domain: TrustDomain::from_str("example.org").unwrap(),
-                path: "/PATH/Element".to_string(),
-            }
-        ),
-
-        from_str_uri_maximum_length: (
-            &format!("spiffe://domain.test/{}", "a".repeat(2027)),
-            SpiffeId {
-                trust_domain: TrustDomain::from_str("domain.test").unwrap(),
-                path: format!("/{}","a".repeat(2027)),
             }
         ),
     }
@@ -390,18 +435,17 @@ mod spiffe_id_tests {
 
     spiffe_id_error_tests! {
         from_empty_str: ("", SpiffeIdError::Empty),
-        from_blank_str: (" ", SpiffeIdError::Empty),
         from_str_invalid_uri_str_contains_ip_address: (
             "192.168.2.2:6688",
-            SpiffeIdError::CannotParseUri(ParseError::RelativeUrlWithoutBase),
+            SpiffeIdError::WrongScheme,
         ),
         from_str_uri_str_invalid_scheme: (
             "http://domain.test/path/element",
-            SpiffeIdError::InvalidScheme,
+            SpiffeIdError::WrongScheme,
         ),
         from_str_uri_str_empty_authority: (
             "spiffe:/path/element",
-            SpiffeIdError::MissingTrustDomain,
+            SpiffeIdError::WrongScheme,
         ),
         from_str_uri_str_empty_authority_after_slashes: (
             "spiffe:///path/element",
@@ -409,28 +453,82 @@ mod spiffe_id_tests {
         ),
         from_str_uri_str_empty_authority_no_slashes: (
             "spiffe:path/element",
-            SpiffeIdError::MissingTrustDomain,
+            SpiffeIdError::WrongScheme,
         ),
         from_str_uri_str_with_query: (
             "spiffe://domain.test/path/element?query=1",
-            SpiffeIdError::QueryNotAllowed,
+            SpiffeIdError::BadPathSegmentChar,
         ),
         from_str_uri_str_with_fragment: (
             "spiffe://domain.test/path/element#fragment-1",
-            SpiffeIdError::FragmentNotAllowed,
+            SpiffeIdError::BadPathSegmentChar,
         ),
         from_str_uri_str_with_port: (
             "spiffe://domain.test:8080/path/element",
-            SpiffeIdError::PortNotAllowed,
+            SpiffeIdError::BadTrustDomainChar,
         ),
         from_str_uri_str_with_user_info: (
             "spiffe://user:password@test.org/path/element",
-            SpiffeIdError::UserInfoNotAllowed,
+            SpiffeIdError::BadTrustDomainChar,
         ),
-        from_str_uri_exceeds_maximum_length: (
-            &format!("spiffe://domain.test/{}", "a".repeat(2028)),
-            SpiffeIdError::IdTooLong,
+        from_str_uri_str_with_trailing_slash: (
+            "spiffe://test.org/",
+            SpiffeIdError::TrailingSlash,
         ),
+        from_str_uri_str_with_emtpy_segment: (
+            "spiffe://test.org//",
+            SpiffeIdError::EmptySegment,
+        ),
+        from_str_uri_str_with_path_with_trailing_slash: (
+            "spiffe://test.org/path/other/",
+            SpiffeIdError::TrailingSlash,
+        ),
+        from_str_uri_str_with_dot_segment: (
+            "spiffe://test.org/./other",
+            SpiffeIdError::DotSegment,
+        ),
+        from_str_uri_str_with_double_dot_segment: (
+            "spiffe://test.org/../other",
+            SpiffeIdError::DotSegment,
+        ),
+    }
+
+    #[test]
+    fn test_parse_with_all_chars() {
+        // Go all the way through 255, which ensures we reject UTF-8 appropriately
+        for i in 0..=255_u8 {
+            let c = i as char;
+
+            // Don't test '/' since it is the delimiter between path segments
+            if c == '/' {
+                continue;
+            }
+
+            let path = format!("/path{}", c);
+            let id = format!("spiffe://trustdomain{}", path);
+
+            if PATH_CHARS.contains(&c) {
+                let spiffe_id = SpiffeId::new(&id).unwrap();
+                assert_eq!(spiffe_id.to_string(), id)
+            } else {
+                assert_eq!(
+                    SpiffeId::new(&id).unwrap_err(),
+                    SpiffeIdError::BadPathSegmentChar
+                );
+            }
+
+            let td = format!("spiffe://trustdomain{}", c);
+
+            if TD_CHARS.contains(&c) {
+                let spiffe_id = SpiffeId::new(&td).unwrap();
+                assert_eq!(spiffe_id.to_string(), td)
+            } else {
+                assert_eq!(
+                    SpiffeId::new(&td).unwrap_err(),
+                    SpiffeIdError::BadTrustDomainChar
+                );
+            }
+        }
     }
 }
 
@@ -439,7 +537,8 @@ mod trust_domain_tests {
 
     use super::*;
     use std::str::FromStr;
-    use url::ParseError;
+
+    use super::spiffe_id_tests::TD_CHARS;
 
     macro_rules! trust_domain_success_tests {
         ($($name:ident: $value:expr,)*) => {
@@ -455,12 +554,9 @@ mod trust_domain_tests {
     }
 
     trust_domain_success_tests! {
-        from_str_domain: ("example.org", TrustDomain{name: "example.org".to_string()}),
-        from_str_domain_uppercase: ("  EXAMPLE.org ", TrustDomain{name: "example.org".to_string()}),
+        from_str_domain: ("trustdomain", TrustDomain{name: "trustdomain".to_string()}),
         from_str_spiffeid: ("spiffe://other.test", TrustDomain{name: "other.test".to_string()}),
         from_str_spiffeid_with_path: ("spiffe://domain.test/path/element", TrustDomain{name: "domain.test".to_string()}),
-        from_str_spiffeid_with_wrapped_uir: ("spiffe://domain.test/spiffe://domain.test:80/path/element", TrustDomain{name: "domain.test".to_string()}),
-        from_max_length_str: (&"a".repeat(255), TrustDomain{name: "a".repeat(255)}),
     }
 
     macro_rules! trust_domain_error_tests {
@@ -479,14 +575,12 @@ mod trust_domain_tests {
 
     trust_domain_error_tests! {
         from_empty_str: ("", SpiffeIdError::MissingTrustDomain),
-        from_empty_blank: ("  ", SpiffeIdError::MissingTrustDomain),
-        from_invalid_scheme:  ("other://domain.test", SpiffeIdError::InvalidScheme),
-        from_uri_with_port: ("spiffe://domain.test:80", SpiffeIdError::PortNotAllowed),
-        from_uri_with_userinfo: ("spiffe://user:pass@domain.test", SpiffeIdError::UserInfoNotAllowed),
-        from_uri_with_invalid_domain: ("spiffe:// domain.test", SpiffeIdError::CannotParseUri(ParseError::InvalidDomainCharacter)),
-        from_uri_with_empty_scheme: ("://domain.test", SpiffeIdError::CannotParseUri(ParseError::RelativeUrlWithoutBase)),
+        from_invalid_scheme:  ("other://domain.test", SpiffeIdError::WrongScheme),
+        from_uri_with_port: ("spiffe://domain.test:80", SpiffeIdError::BadTrustDomainChar),
+        from_uri_with_userinfo: ("spiffe://user:pass@domain.test", SpiffeIdError::BadTrustDomainChar),
+        from_uri_with_invalid_domain: ("spiffe:// domain.test", SpiffeIdError::BadTrustDomainChar),
+        from_uri_with_empty_scheme: ("://domain.test", SpiffeIdError::WrongScheme),
         from_uri_with_empty_domain: ("spiffe:///path", SpiffeIdError::MissingTrustDomain),
-        from_uri_exceeds_maximum_length: (&"a".repeat(256), SpiffeIdError::TrustDomainTooLong),
     }
 
     #[test]
@@ -505,7 +599,7 @@ mod trust_domain_tests {
 
     #[test]
     fn test_to_string() {
-        let trust_domain = TrustDomain::from_str("example.org").unwrap();
+        let trust_domain = TrustDomain::from_str("spiffe://example.org").unwrap();
         assert_eq!(trust_domain.to_string(), "example.org");
     }
 
@@ -525,5 +619,24 @@ mod trust_domain_tests {
     fn test_try_from_string() {
         let trust_domain = TrustDomain::try_from(String::from("example.org")).unwrap();
         assert_eq!(trust_domain.to_string(), "example.org");
+    }
+
+    #[test]
+    fn test_parse_with_all_chars() {
+        // Go all the way through 255, which ensures we reject UTF-8 appropriately
+        for i in 0..=255_u8 {
+            let c = i as char;
+            let td = format!("trustdomain{}", c);
+
+            if TD_CHARS.contains(&c) {
+                let trust_domain = TrustDomain::new(&td).unwrap();
+                assert_eq!(trust_domain.to_string(), td)
+            } else {
+                assert_eq!(
+                    TrustDomain::new(&td).unwrap_err(),
+                    SpiffeIdError::BadTrustDomainChar
+                );
+            }
+        }
     }
 }

--- a/src/spiffe_id/mod.rs
+++ b/src/spiffe_id/mod.rs
@@ -94,7 +94,7 @@ impl SpiffeId {
             return Err(SpiffeIdError::Empty);
         }
 
-        if !id.contains(SCHEME_PREFIX) {
+        if &id[..SCHEME_PREFIX.len()] != SCHEME_PREFIX {
             return Err(SpiffeIdError::WrongScheme);
         }
 
@@ -183,7 +183,7 @@ fn validate_path(path: &str) -> Result<(), SpiffeIdError> {
         return Ok(());
     }
 
-    if (path.as_bytes()[0] as char) != '/' {
+    if !path.starts_with('/') {
         return Err(SpiffeIdError::NoLeadingSlash);
     }
 

--- a/src/spiffe_id/mod.rs
+++ b/src/spiffe_id/mod.rs
@@ -191,7 +191,10 @@ fn validate_path(path: &str) -> Result<(), SpiffeIdError> {
     let mut segment_end = 0;
 
     while segment_end < path.len() {
-        let c = path.as_bytes()[segment_end] as char;
+        let c = match path.chars().nth(segment_end) {
+            None => break,
+            Some(c) => c,
+        };
         if c == '/' {
             match &path[segment_start..segment_end] {
                 "/" => return Err(SpiffeIdError::EmptySegment),


### PR DESCRIPTION
Changes SPIFFE ID module to provide uniform and safe SPIFFE ID parsing that conforms with the latest discussions in SIG-SPEC around allowed characters and shape of a SPIFFE ID:

- Allowed characters for Trustdomain names are `['a'..'z', '0'..'9', '.', '-'. '_']`.
- Allowed characters for path segments are `['a'..'z', '0'..'9', 'A'..'Z', '.', '-'. '_']`.
- SPIFFE IDs cannot have empty segments, e.g. `spiffe://trustdomain//path`.
- SPIFFE IDs cannot have dot segments, e.g. `spiffe://trustdomain/./path` or `spiffe://trustdomain/../path`.
- SPIFFE IDs cannot have a trailing slash, e.g. `spiffe://trustdomain/path/`.


Signed-off-by: Max Lambrecht <maxlambrecht@gmail.com>