### PR TITLE
Parse `JwtSvid` from given token after validating using then Workload API.

### DIFF
--- a/src/workload_api/client.rs
+++ b/src/workload_api/client.rs
@@ -302,13 +302,13 @@ impl WorkloadApiClient {
         }
     }
 
-    /// Validates a JWT SVID token against the given audience. Returns the [`SpiffeId`] of the
-    /// SVID and the JWT claims.
+    /// Validates a JWT SVID token against the given audience. Returns the [`JwtSvid`] parsed from
+    /// the validated token.
     ///
     /// # Arguments
     ///
     /// * `audience`  - The audience of the validating party. Cannot be empty nor contain an empty string.
-    /// * `jwt_svid` - The token to validate.
+    /// * `jwt_token` - The JWT token to validate.
     ///
     /// # Errors
     ///
@@ -319,7 +319,10 @@ impl WorkloadApiClient {
         audience: T,
         jwt_token: &str,
     ) -> Result<JwtSvid, ClientError> {
-        self.validate_jwt(audience, jwt_token)?;
+        // validate token with Workload API, the returned claims and spiffe_id are ignored as
+        // they are parsed from token when the `JwtSvid` object is created, this way we avoid having
+        // to validate that the response from the Workload API contains correct claims.
+        let _ = self.validate_jwt(audience, jwt_token)?;
         let jwt_svid = JwtSvid::parse_insecure(jwt_token)?;
         Ok(jwt_svid)
     }

--- a/tests/workload_api_client_test.rs
+++ b/tests/workload_api_client_test.rs
@@ -18,9 +18,12 @@ fn fetch_jwt_svid() {
 fn fetch_and_validate_jwt_token() {
     let client = WorkloadApiClient::default().unwrap();
     let token = client.fetch_jwt_token(&["my_audience"], None).unwrap();
-    let (spiffe_id, claims) = client.validate_jwt_token("my_audience", &token).unwrap();
-    assert_eq!(claims.unwrap().get_aud(), &["my_audience"]);
-    assert_eq!(spiffe_id.to_string(), "spiffe://example.org/myservice");
+    let jwt_svid = client.validate_jwt_token("my_audience", &token).unwrap();
+    assert_eq!(jwt_svid.audience(), &["my_audience"]);
+    assert_eq!(
+        jwt_svid.spiffe_id().to_string(),
+        "spiffe://example.org/myservice"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Change the `validate_jwt_token` method so it parses a `JwtSvid` from the given token after validating it using the Workload API, this way it no longer returns the claims and spiffe_id from the WL API response but a complete `JwtSvid` with all the information in the token. This is the way that that method is implemented in the rest of SPIFFE libraries. 

Address #7 

Signed-off-by: Max Lambrecht <maxlambrecht@gmail.com>