### PR TITLE
Prepare spiffe 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 
-## 0.1.2 (July 6, 2021)
+## 0.2.0 (July 6, 2021)
 
   * Strict SPIFFE ID parsing (#8)
   * Method `validate_jwt_token` returns a `JwtSvid` parsed 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 
+## 0.1.2 (July 6, 2021)
+
+  * Strict SPIFFE ID parsing (#8)
+  * Method `validate_jwt_token` returns a `JwtSvid` parsed 
+    from given token after validating it using then Workload API (#9)
+
 ## 0.1.1 (June 18, 2021)
-  * Add method `validate_jwt_token` in the WorkloadApiClient.
+  * Add method `validate_jwt_token` in the WorkloadApiClient (#2).
 
 ## 0.1.0 (June 14, 2021)
 
-Initial implementation of the library:
+Initial implementation of the library (#1):
   * Workload API client with one-shot call methods
   * Certificate and PrivateKey types
   * X.509 SVID and bundle types

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "spiffe"
 # When releasing to crates.io:
 # - Update CHANGELOG.md.
 # - Create a new tag
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Max Lambrecht <maxlambrecht@gmail.com>"]
 description = "Rust client library implementation for SPIFFE"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "spiffe"
 # When releasing to crates.io:
 # - Update CHANGELOG.md.
 # - Create a new tag
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Max Lambrecht <maxlambrecht@gmail.com>"]
 description = "Rust client library implementation for SPIFFE"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To use `spiffe`, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spiffe = "0.1.1"
+spiffe = "0.1.2"
 ```
 
 ### Examples

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To use `spiffe`, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spiffe = "0.1.2"
+spiffe = "0.2.0"
 ```
 
 ### Examples


### PR DESCRIPTION
## 0.2.0 

  * Strict SPIFFE ID parsing (#8)
  * Method `validate_jwt_token` returns a `JwtSvid` parsed 
    from given token after validating it using then Workload API (#9)
