### PR TITLE
Update CI script to point to SPIRE 1.0

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -4,22 +4,37 @@
 
 set -euf -o pipefail
 
+spire_folder="spire-858d04b"
+
+function cleanup() {
+  killall -9 spire-agent || true
+  killall -9 spire-server || true
+  rm -f /tmp/spire-server/private/api.sock
+  rm -f /tmp/spire-agent/public/api.sock
+  rm -rf ${spire_folder}
+}
+
+cleanup
+
 # Install and run a SPIRE server
-curl -s -N -L https://github.com/spiffe/spire/releases/download/v0.12.3/spire-0.12.3-linux-x86_64-glibc.tar.gz | tar xz
-pushd spire-0.12.3
+curl -s -N -L https://github.com/spiffe/spire/releases/download/v1.0.0/spire-1.0.0-linux-x86_64-glibc.tar.gz | tar xz
+pushd "${spire_folder}"
 bin/spire-server run -config conf/server/server.conf &
-sleep 5
+sleep 10
 
 # Run the SPIRE agent with the joint token
 bin/spire-server token generate -spiffeID spiffe://example.org/myagent > token
 cut -d ' ' -f 2 token > token_stripped
 bin/spire-agent run -config conf/agent/agent.conf -joinToken "$(< token_stripped)" &
-sleep 5
+sleep 10
 
 # Register the workload through UID with the SPIFFE ID "spiffe://example.org/myservice"
 bin/spire-server entry create -parentID spiffe://example.org/myagent -spiffeID spiffe://example.org/myservice -selector unix:uid:$(id -u)
-sleep 5
+sleep 10
 popd
 
-export SPIFFE_ENDPOINT_SOCKET="unix:/tmp/agent.sock"
+export SPIFFE_ENDPOINT_SOCKET="unix:/tmp/spire-agent/public/api.sock"
+
 RUST_BACKTRACE=1 cargo test -- --include-ignored
+
+cleanup

--- a/ci.sh
+++ b/ci.sh
@@ -4,6 +4,7 @@
 
 set -euf -o pipefail
 
+# name of the spire folder in the release tar
 spire_folder="spire-858d04b"
 
 function cleanup() {

--- a/tests/workload_api_client_test.rs
+++ b/tests/workload_api_client_test.rs
@@ -80,17 +80,15 @@ fn fetch_x509_context() {
     assert_eq!(bundle.authorities().len(), 1);
 }
 
-// Enable after SPIRE 1.0 is released and CI script points to it,
-// as the current version of the Workload API doesn't have the fetch_x509_bundles method.
-// #[test]
-// #[ignore]
-// fn fetch_x509_bundles() {
-//     let client = WorkloadApiClient::default().unwrap();
-//     let bundles = client.fetch_x509_bundles().unwrap();
-//
-//     let bundle = bundles.get_bundle_for_trust_domain(&TrustDomain::new("example.org").unwrap());
-//     let bundle = bundle.unwrap().unwrap();
-//
-//     assert_eq!(bundle.trust_domain().to_string(), "example.org");
-//     assert_eq!(bundle.authorities().len(), 1);
-// }
+#[test]
+#[ignore]
+fn fetch_x509_bundles() {
+    let client = WorkloadApiClient::default().unwrap();
+    let bundles = client.fetch_x509_bundles().unwrap();
+
+    let bundle = bundles.get_bundle_for_trust_domain(&TrustDomain::new("example.org").unwrap());
+    let bundle = bundle.unwrap().unwrap();
+
+    assert_eq!(bundle.trust_domain().to_string(), "example.org");
+    assert_eq!(bundle.authorities().len(), 1);
+}


### PR DESCRIPTION
Add some cleaning up before installing SPIRE so it is easier to run the script locally.
Also add fetch-x509-bundles integration test.

Signed-off-by: Max Lambrecht <maxlambrecht@gmail.com>