### PR TITLE
Replace chrono by time crate and update other dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,19 +15,19 @@ categories = ["cryptography"]
 keywords = ["SPIFFE", "X509", "JWT"]
 
 [dependencies]
-protobuf = "2.24.1"
-futures = "0.3.15"
-thiserror = "1.0.25"
-url = "2.2.2"
-asn1 = { package = "simple_asn1", version = "0.5.3" }
-x509-parser = "0.9.2"
-pkcs8 = "0.7.0"
-jsonwebtoken = "7.2.0"
-jsonwebkey = { version = "0.3.2", features = ["jsonwebtoken", "jwt-convert"] }
-serde = { version = "1.0.126", features = ["derive"] }
-serde_json = "1.0.64"
-chrono = { version = "0.4.19", features = ["serde"] }
-zeroize = { version = "1.3.0", features = ["zeroize_derive"] }
+protobuf = "2.27"
+futures = "0.3"
+thiserror = "1.0"
+url = "2.2"
+asn1 = { package = "simple_asn1", version = "0.6" }
+x509-parser = "0.13"
+pkcs8 = "0.8"
+jsonwebtoken = "7.2"
+jsonwebkey = { version = "0.3", features = ["jsonwebtoken", "jwt-convert"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+zeroize = { version = "1.4", features = ["zeroize_derive"] }
+time = "0.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 grpcio = { version = "0.9", default-features = false, features = ["protobuf-codec"] }
@@ -37,8 +37,8 @@ grpcio = { version = "0.9", default-features = false, features = ["protobuf-code
 
 
 [dev-dependencies]
-jsonwebkey = { version = "0.3.2", features = ["generate"] }
+jsonwebkey = { version = "0.3", features = ["generate"] }
 
-# used to verify in tests that the certificates bytes from the X.509 SVIDs and bundle authorities
+# used to verify in tests that the certificates bytes from the X.509 S10IDs and bundle authorities
 # are parseable as OpenSSL X.509 certificates.
-openssl = { version = "0.10.35", features = ["vendored"] }
+openssl = { version = "0.10", features = ["vendored"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,6 @@ grpcio = { version = "0.9", default-features = false, features = ["protobuf-code
 [dev-dependencies]
 jsonwebkey = { version = "0.3", features = ["generate"] }
 
-# used to verify in tests that the certificates bytes from the X.509 S10IDs and bundle authorities
+# used to verify in tests that the certificates bytes from the X.509 SVIDs and bundle authorities
 # are parseable as OpenSSL X.509 certificates.
 openssl = { version = "0.10", features = ["vendored"] }

--- a/src/cert/parsing.rs
+++ b/src/cert/parsing.rs
@@ -46,10 +46,9 @@ pub(crate) fn get_x509_extension<'a, 'b>(
     cert: &'a X509Certificate<'_>,
     oid: &'b Oid<'a>,
 ) -> Result<&'a ParsedExtension<'a>, CertificateError> {
-    let extensions = &cert.tbs_certificate.extensions;
-    let parsed_extension = match extensions.get(oid) {
+    let parsed_extension = match &cert.tbs_certificate.get_extension_unique(&oid)? {
         None => {
-            return Err(CertificateError::MissingX509Extension(oid.to_string()));
+            return Err(CertificateError::MissingX509Extension(oid.to_string()))
         }
         Some(s) => s.parsed_extension(),
     };


### PR DESCRIPTION
Replace chrono dependency by time crate.
Update x509-parser, asn1, and zeroize deps to no longer depend on chrono crate.
Update some other dependencies.

This is part of the work to solve #17 

Signed-off-by: Max Lambrecht <maxlambrecht@gmail.com>