### PR TITLE
Use bindgen on non-linux platforms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ time = "0.3"
 [target.'cfg(target_os = "linux")'.dependencies]
 grpcio = { version = "0.9", default-features = false, features = ["protobuf-codec"] }
 
-[target.'cfg(target_os = "macos")'.dependencies]
+[target.'cfg(not(target_os = "linux"))'.dependencies]
 grpcio = { version = "0.9", default-features = false, features = ["protobuf-codec", "use-bindgen"] }
 
 


### PR DESCRIPTION
grpcio-sys doesn't have pre-gen bindings for non-linux platforms. fix the cfg from  `target_os = "macos"` to `not(target_os = "linux")` to allow building on other platforms.