### PR TITLE
Update grpcio dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,12 +28,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 zeroize = { version = "1.4", features = ["zeroize_derive"] }
 time = "0.3"
-
-[target.'cfg(target_os = "linux")'.dependencies]
-grpcio = { version = "0.9", default-features = false, features = ["protobuf-codec"] }
-
-[target.'cfg(not(target_os = "linux"))'.dependencies]
-grpcio = { version = "0.9", default-features = false, features = ["protobuf-codec", "use-bindgen"] }
+grpcio = { version = "0.12", default-features = false, features = ["protobuf-codec"] }
 
 
 [dev-dependencies]


### PR DESCRIPTION
Update grpcio to `0.12` and remove "use-bindgen" feature as it doesn't exist anymore: [#558](https://github.com/tikv/grpc-rs/pull/558): `Features use-bindgen is removed as it can be detected during compile time now.`