### PR TITLE
Refactoring `spiffe` crate: Introducing `spiffe-types` and `workload-api` features

### DIFF
--- a/spiffe/Cargo.toml
+++ b/spiffe/Cargo.toml
@@ -15,12 +15,7 @@ categories = ["cryptography"]
 keywords = ["SPIFFE", "X509", "JWT"]
 
 [dependencies]
-tonic = { version = "0.9", default-features = false, features = ["prost", "codegen", "transport"]}
-prost = { version = "0.11"}
-prost-types = {version = "0.11"}
-tokio = { "version" = "1", features = ["net", "test-util"]}
-tokio-stream = "0.1"
-tower = { version = "0.4", features = ["util"] }
+# spiffe-types dependencies:
 thiserror = "1.0"
 url = "2.2"
 asn1 = { package = "simple_asn1", version = "0.6" }
@@ -32,7 +27,14 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 zeroize = { version = "1.6", features = ["zeroize_derive"] }
 time = "0.3"
+tonic = { version = "0.9"}
 
+# workload-api dependencies:
+prost = { version = "0.11", optional = true }
+prost-types = { version = "0.11", optional = true }
+tokio = { version = "1", features = ["net", "test-util"], optional = true }
+tokio-stream = { version = "0.1", optional = true }
+tower = { version = "0.4", features = ["util"], optional = true }
 
 [dev-dependencies]
 jsonwebkey = { version = "0.3", features = ["generate"] }
@@ -49,4 +51,7 @@ prost-build = "0.11"
 anyhow = "1.0.65"
 
 [features]
+default = ["spiffe-types", "workload-api"]
+spiffe-types = []
+workload-api = ["prost", "prost-types", "tokio", "tokio-stream", "tower"]
 integration-tests = []

--- a/spiffe/README.md
+++ b/spiffe/README.md
@@ -63,7 +63,7 @@ let x509_bundle: &X509Bundle = x509_bundles.get_bundle(&trust_domain)?;
 let x509_authorities: &Vec<Certificate> = x509_bundle.authorities();
 
 // watch for updates on the X.509 context
-let mut x509_context_stream = client.x509_context_stream().await?;
+let mut x509_context_stream = client.stream_x509_contexts().await?;
 while let Some(x509_context_update) = x509_context_stream.next().await {
     match x509_context_update {
         Ok(update) => {

--- a/spiffe/README.md
+++ b/spiffe/README.md
@@ -9,7 +9,8 @@ This utility library enables interaction with the [SPIFFE Workload API](https://
 
 ## Getting Started
 
-Include `spiffe` in your `Cargo.toml` dependencies:
+Include `spiffe` in your `Cargo.toml` dependencies to get both the SPIFFE types (`spiffe-types`) and the Workload API
+client (`workload-api`) by default:
 
 ```toml
 [dependencies]
@@ -62,7 +63,7 @@ let x509_bundle: &X509Bundle = x509_bundles.get_bundle(&trust_domain)?;
 let x509_authorities: &Vec<Certificate> = x509_bundle.authorities();
 
 // watch for updates on the X.509 context
-let mut x509_context_stream = client.watch_x509_context_stream().await?;
+let mut x509_context_stream = client.x509_context_stream().await?;
 while let Some(x509_context_update) = x509_context_stream.next().await {
     match x509_context_update {
         Ok(update) => {
@@ -75,7 +76,7 @@ while let Some(x509_context_update) = x509_context_stream.next().await {
 }
 
 // watch for updates on the X.509 bundles 
-let mut x509_bundle_stream = client.watch_x509_bundles_stream().await?;
+let mut x509_bundle_stream = client.stream_x509_bundles().await?;
 while let Some(x509_bundle_update) = x509_bundle_stream.next().await {
     match x509_bundle_update {
         Ok(update) => {
@@ -118,7 +119,7 @@ let jwt_authority: &JwtAuthority = jwt_bundle.find_jwt_authority("a_key_id")?;
 let validated_jwt_svid = JwtSvid::parse_and_validate(&jwt_token, &jwt_bundles_set, &["service1.com"])?;
 
 // watch for updates on the JWT bundles 
-let mut jwt_bundle_stream = client.watch_jwt_bundles_stream().await?;
+let mut jwt_bundle_stream = client.stream_jwt_bundles().await?;
 while let Some(jwt_bundle_update) = jwt_bundle_stream.next().await {
     match jwt_bundle_update {
         Ok(update) => {

--- a/spiffe/src/constants.rs
+++ b/spiffe/src/constants.rs
@@ -1,0 +1,11 @@
+//! Module defining constants used within the Rust-Spiffe library.
+
+/// Specifies the index of the default SVID (Secure Vector Identifier) within a list.
+/// This constant is used to identify the first SVID in the list returned by the Workload API,
+/// which is considered the default for operations involving multiple SVIDs.
+pub const DEFAULT_SVID: usize = 0;
+
+/// Name of the environment variable that is used to configure the socket endpoint path for SPIFFE.
+/// This path is required for communication between SPIFFE-enabled systems and should be set within
+/// the environment variables of the host.
+pub const SPIFFE_SOCKET_ENV: &str = "SPIFFE_ENDPOINT_SOCKET";

--- a/spiffe/src/error.rs
+++ b/spiffe/src/error.rs
@@ -1,0 +1,100 @@
+//! Defines errors related to interactions with the GRPC client, including handling of X.509 and JWT materials,
+//! SPIFFE endpoint socket path validation, and other potential failure points within the Rust-Spiffe library.
+//! This encompasses errors related to endpoint configuration, response handling, data processing, and specific
+//! errors for various SPIFFE components.
+
+use crate::bundle::jwt::JwtBundleError;
+use crate::bundle::x509::X509BundleError;
+use crate::spiffe_id::SpiffeIdError;
+use crate::svid::jwt::JwtSvidError;
+use crate::svid::x509::X509SvidError;
+use thiserror::Error;
+use url::ParseError;
+
+/// Errors that may arise while interacting with and fetching materials from a GRPC client.
+/// Includes errors related to endpoint configuration, response handling, and data processing.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum GrpcClientError {
+    /// Missing environment variable for the endpoint socket address.
+    #[error("missing endpoint socket address environment variable (SPIFFE_ENDPOINT_SOCKET)")]
+    MissingEndpointSocketPath,
+
+    /// The GRPC client received an empty response.
+    #[error("received an empty response from the GRPC client")]
+    EmptyResponse,
+
+    /// Invalid endpoint socket path configuration.
+    #[error("invalid endpoint socket path")]
+    InvalidEndpointSocketPath(#[from] SocketPathError),
+
+    /// Failed to parse the X509Svid response from the client.
+    #[error("failed to process X509Svid response")]
+    InvalidX509Svid(#[from] X509SvidError),
+
+    /// Failed to parse the JwtSvid response from the client.
+    #[error("failed to process JwtSvid response")]
+    InvalidJwtSvid(#[from] JwtSvidError),
+
+    /// Failed to parse the X509Bundle response from the client.
+    #[error("failed to process X509Bundle response")]
+    InvalidX509Bundle(#[from] X509BundleError),
+
+    /// Failed to parse the JwtBundle response from the client.
+    #[error("failed to process JwtBundle response")]
+    InvalidJwtBundle(#[from] JwtBundleError),
+
+    /// Invalid trust domain in the bundles response.
+    #[error("invalid trust domain in bundles response")]
+    InvalidTrustDomain(#[from] SpiffeIdError),
+
+    /// Error returned by the GRPC library for error responses from the client.
+    #[error("error response from the GRPC client")]
+    Grpc(#[from] tonic::Status),
+
+    /// Error returned by the GRPC library when creating a transport channel.
+    #[error("error creating transport channel to the GRPC client")]
+    Transport(#[from] tonic::transport::Error),
+}
+
+/// Errors related to the validation of a SPIFFE endpoint socket path.
+/// These cover scenarios such as invalid URI schemes, missing components, and unexpected URI structure.
+#[derive(Debug, Error, PartialEq, Copy, Clone)]
+#[non_exhaustive]
+pub enum SocketPathError {
+    /// The SPIFFE endpoint socket URI has a scheme other than 'unix' or 'tcp'.
+    #[error("workload endpoint socket URI must have a tcp:// or unix:// scheme")]
+    InvalidScheme,
+
+    /// The SPIFFE endpoint unix socket URI does not include a path.
+    #[error("workload endpoint unix socket URI must include a path")]
+    UnixAddressEmptyPath,
+
+    /// The SPIFFE endpoint tcp socket URI include a path.
+    #[error("workload endpoint tcp socket URI must not include a path")]
+    TcpAddressNonEmptyPath,
+
+    /// The SPIFFE endpoint socket URI has query values.
+    #[error("workload endpoint socket URI must not include query values")]
+    HasQueryValues,
+
+    /// The SPIFFE endpoint socket URI has a fragment.
+    #[error("workload endpoint socket URI must not include a fragment")]
+    HasFragment,
+
+    /// The SPIFFE endpoint socket URI has query user info.
+    #[error("workload endpoint socket URI must not include user info")]
+    HasUserInfo,
+
+    /// The SPIFFE endpoint tcp socket URI has misses a host.
+    #[error("workload endpoint tcp socket URI must include a host")]
+    TcpEmptyHost,
+
+    /// The SPIFFE endpoint tcp socket URI has misses a port.
+    #[error("workload endpoint tcp socket URI host component must be an IP:port")]
+    TcpAddressNoIpPort,
+
+    /// Error returned by the URI parsing library.
+    #[error("workload endpoint socket is not a valid URI")]
+    Parse(#[from] ParseError),
+}

--- a/spiffe/src/lib.rs
+++ b/spiffe/src/lib.rs
@@ -81,9 +81,29 @@
 //! # }
 //! ```
 
+#[cfg(feature = "spiffe-types")]
+pub mod constants;
+
+#[cfg(feature = "spiffe-types")]
 pub mod bundle;
+
+#[cfg(feature = "spiffe-types")]
 pub mod cert;
-pub(crate) mod proto;
+
+#[cfg(feature = "spiffe-types")]
 pub mod spiffe_id;
+
+#[cfg(feature = "spiffe-types")]
 pub mod svid;
+
+#[cfg(feature = "spiffe-types")]
+pub mod error;
+
+#[cfg(feature = "spiffe-types")]
+pub mod endpoint;
+
+#[cfg(feature = "workload-api")]
+pub(crate) mod proto;
+
+#[cfg(feature = "workload-api")]
 pub mod workload_api;

--- a/spiffe/src/workload_api/client.rs
+++ b/spiffe/src/workload_api/client.rs
@@ -33,7 +33,7 @@
 //! let x509_context: X509Context = client.fetch_x509_context().await?;
 //!
 //! // watch for updates on the X.509 context
-//! let mut x509_context_stream = client.watch_x509_context_stream().await?;
+//! let mut x509_context_stream = client.stream_x509_contexts().await?;
 //! while let Some(x509_context_update) = x509_context_stream.next().await {
 //!     match x509_context_update {
 //!         Ok(context) => {
@@ -51,22 +51,20 @@
 
 use std::str::FromStr;
 
-use thiserror::Error;
-
-use crate::bundle::jwt::{JwtBundle, JwtBundleError, JwtBundleSet};
-use crate::bundle::x509::{X509Bundle, X509BundleError, X509BundleSet};
-use crate::spiffe_id::{SpiffeId, SpiffeIdError, TrustDomain};
-use crate::svid::jwt::{JwtSvid, JwtSvidError};
-use crate::svid::x509::{X509Svid, X509SvidError};
-use crate::workload_api::address::{
-    get_default_socket_path, validate_socket_path, SocketPathError,
-};
+use crate::bundle::jwt::{JwtBundle, JwtBundleSet};
+use crate::bundle::x509::{X509Bundle, X509BundleSet};
+use crate::endpoint::{get_default_socket_path, validate_socket_path};
+use crate::spiffe_id::{SpiffeId, TrustDomain};
+use crate::svid::jwt::JwtSvid;
+use crate::svid::x509::X509Svid;
 use crate::workload_api::x509_context::X509Context;
 use std::convert::TryFrom;
 
 use tokio::net::UnixStream;
 use tokio_stream::{Stream, StreamExt};
 
+use crate::constants::DEFAULT_SVID;
+use crate::error::GrpcClientError;
 use crate::proto::workload::{
     spiffe_workload_api_client::SpiffeWorkloadApiClient, JwtBundlesRequest, JwtBundlesResponse,
     JwtsvidRequest, JwtsvidResponse, ValidateJwtsvidRequest, ValidateJwtsvidResponse,
@@ -75,56 +73,8 @@ use crate::proto::workload::{
 use tonic::transport::{Endpoint, Uri};
 use tower::service_fn;
 
-/// The default SVID is the first in the list of SVIDs returned by the Workload API.
-pub const DEFAULT_SVID: usize = 0;
-
 const SPIFFE_HEADER_KEY: &str = "workload.spiffe.io";
 const SPIFFE_HEADER_VALUE: &str = "true";
-
-/// An error that may arise fetching X.509 and JWT materials with the [`WorkloadApiClient`].
-#[derive(Debug, Error)]
-#[non_exhaustive]
-pub enum ClientError {
-    /// The environment variable `SPIFFE_ENDPOINT_SOCKET` is not set.
-    #[error("endpoint socket address environment variable is not set")]
-    MissingEndpointSocketPath,
-
-    /// The Workload API returned an empty response.
-    #[error("empty response from the Workload API")]
-    EmptyResponse,
-
-    /// The configured Endpoint Socket path is not valid.
-    #[error("invalid endpoint socket path")]
-    EndpointSocketPath(#[from] SocketPathError),
-
-    /// The Workload API response cannot be parsed as a [`X509Svid`].
-    #[error("cannot process X509Svid response")]
-    InvalidX509Svid(#[from] X509SvidError),
-
-    /// The Workload API response cannot be parsed as a [`JwtSvid`].
-    #[error("cannot process X509Svid response")]
-    InvalidJwtSvid(#[from] JwtSvidError),
-
-    /// The Workload API response cannot be parsed as a [`X509Bundle`].
-    #[error("cannot process X509Bundle response")]
-    InvalidX509Bundle(#[from] X509BundleError),
-
-    /// The Workload API response cannot be parsed as a [`JwtBundle`].
-    #[error("cannot process JwtBundle response")]
-    InvalidJwtBundle(#[from] JwtBundleError),
-
-    /// The Workload API response contains an invalid [`TrustDomain`]
-    #[error("trust domain in bundles response is invalid")]
-    InvalidTrustDomain(#[from] SpiffeIdError),
-
-    /// Error returned by the GRPC library, when there is an error response from the Workload API.
-    #[error("error response from the Workload API")]
-    Grpc(#[from] tonic::Status),
-
-    /// Error returned by the GRPC library when there is an error creating a transport channel to the Workload API.
-    #[error("error creating transport")]
-    Transport(#[from] tonic::transport::Error),
-}
 
 /// This type represents a client to interact with the Workload API.
 ///
@@ -174,7 +124,7 @@ impl WorkloadApiClient {
     /// # Errors
     ///
     /// This function will return an error if the provided socket path is invalid or if there are issues connecting.
-    pub async fn new_from_path(path: &str) -> Result<Self, ClientError> {
+    pub async fn new_from_path(path: &str) -> Result<Self, GrpcClientError> {
         validate_socket_path(path)?;
 
         // Strip the 'unix:' prefix for tonic compatibility.
@@ -202,11 +152,11 @@ impl WorkloadApiClient {
     ///
     /// # Errors
     ///
-    /// The function returns a variant of [`ClientError`] if environment variable is not set or if
+    /// The function returns a variant of [`GrpcClientError`] if environment variable is not set or if
     /// the provided socket path is not valid.
-    pub async fn default() -> Result<Self, ClientError> {
+    pub async fn default() -> Result<Self, GrpcClientError> {
         let socket_path =
-            get_default_socket_path().ok_or(ClientError::MissingEndpointSocketPath)?;
+            get_default_socket_path().ok_or(GrpcClientError::MissingEndpointSocketPath)?;
         Self::new_from_path(socket_path.as_str()).await
     }
 
@@ -219,7 +169,7 @@ impl WorkloadApiClient {
     /// # Returns
     ///
     /// A `Result` containing a `WorkloadApiClient` if successful, or a `ClientError` if an error occurs.
-    pub fn new(conn: tonic::transport::Channel) -> Result<Self, ClientError> {
+    pub fn new(conn: tonic::transport::Channel) -> Result<Self, GrpcClientError> {
         Ok(WorkloadApiClient {
             client: SpiffeWorkloadApiClient::with_interceptor(conn, MetadataAdder {}),
         })
@@ -232,12 +182,12 @@ impl WorkloadApiClient {
     /// # Returns
     ///
     /// On success, it returns a valid [`X509Svid`] which represents the parsed SVID.
-    /// If the fetch operation or the parsing fails, it returns a [`ClientError`].
+    /// If the fetch operation or the parsing fails, it returns a [`GrpcClientError`].
     ///
     /// # Errors
     ///
-    /// Returns [`ClientError`] if the gRPC call fails or if the SVID could not be parsed from the gRPC response.
-    pub async fn fetch_x509_svid(&mut self) -> Result<X509Svid, ClientError> {
+    /// Returns [`GrpcClientError`] if the gRPC call fails or if the SVID could not be parsed from the gRPC response.
+    pub async fn fetch_x509_svid(&mut self) -> Result<X509Svid, GrpcClientError> {
         let request = X509svidRequest::default();
 
         let grpc_stream_response: tonic::Response<tonic::Streaming<X509svidResponse>> =
@@ -247,7 +197,7 @@ impl WorkloadApiClient {
             .into_inner()
             .message()
             .await?
-            .ok_or(ClientError::EmptyResponse)?;
+            .ok_or(GrpcClientError::EmptyResponse)?;
         WorkloadApiClient::parse_x509_svid_from_grpc_response(response)
     }
 
@@ -259,13 +209,13 @@ impl WorkloadApiClient {
     /// # Returns
     ///
     /// On success, it returns a `Vec` containing valid [`X509Svid`] instances, each representing a parsed SVID.
-    /// If the fetch operation or any parsing fails, it returns a [`ClientError`].
+    /// If the fetch operation or any parsing fails, it returns a [`GrpcClientError`].
     ///
     /// # Errors
     ///
-    /// Returns [`ClientError`] if the gRPC call fails, if the SVIDs could not be parsed from the gRPC response,
+    /// Returns [`GrpcClientError`] if the gRPC call fails, if the SVIDs could not be parsed from the gRPC response,
     /// or if the stream unexpectedly terminates.
-    pub async fn fetch_all_x509_svids(&mut self) -> Result<Vec<X509Svid>, ClientError> {
+    pub async fn fetch_all_x509_svids(&mut self) -> Result<Vec<X509Svid>, GrpcClientError> {
         let request = X509svidRequest::default();
 
         let grpc_stream_response: tonic::Response<tonic::Streaming<X509svidResponse>> =
@@ -275,7 +225,7 @@ impl WorkloadApiClient {
             .into_inner()
             .message()
             .await?
-            .ok_or(ClientError::EmptyResponse)?;
+            .ok_or(GrpcClientError::EmptyResponse)?;
         WorkloadApiClient::parse_x509_svids_from_grpc_response(response)
     }
 
@@ -283,9 +233,9 @@ impl WorkloadApiClient {
     ///
     /// # Errors
     ///
-    /// The function returns a variant of [`ClientError`] if there is en error connecting to the Workload API or
+    /// The function returns a variant of [`GrpcClientError`] if there is en error connecting to the Workload API or
     /// there is a problem processing the response.
-    pub async fn fetch_x509_bundles(&mut self) -> Result<X509BundleSet, ClientError> {
+    pub async fn fetch_x509_bundles(&mut self) -> Result<X509BundleSet, GrpcClientError> {
         let request = X509BundlesRequest::default();
 
         let grpc_stream_response: tonic::Response<tonic::Streaming<X509BundlesResponse>> =
@@ -295,7 +245,7 @@ impl WorkloadApiClient {
             .into_inner()
             .message()
             .await?
-            .ok_or(ClientError::EmptyResponse)?;
+            .ok_or(GrpcClientError::EmptyResponse)?;
         WorkloadApiClient::parse_x509_bundle_set_from_grpc_response(response)
     }
 
@@ -303,9 +253,9 @@ impl WorkloadApiClient {
     ///
     /// # Errors
     ///
-    /// The function returns a variant of [`ClientError`] if there is en error connecting to the Workload API or
+    /// The function returns a variant of [`GrpcClientError`] if there is en error connecting to the Workload API or
     /// there is a problem processing the response.
-    pub async fn fetch_jwt_bundles(&mut self) -> Result<JwtBundleSet, ClientError> {
+    pub async fn fetch_jwt_bundles(&mut self) -> Result<JwtBundleSet, GrpcClientError> {
         let request = JwtBundlesRequest::default();
 
         let grpc_stream_response: tonic::Response<tonic::Streaming<JwtBundlesResponse>> =
@@ -315,7 +265,7 @@ impl WorkloadApiClient {
             .into_inner()
             .message()
             .await?
-            .ok_or(ClientError::EmptyResponse)?;
+            .ok_or(GrpcClientError::EmptyResponse)?;
         WorkloadApiClient::parse_jwt_bundle_set_from_grpc_response(response)
     }
 
@@ -324,9 +274,9 @@ impl WorkloadApiClient {
     ///
     /// # Errors
     ///
-    /// The function returns a variant of [`ClientError`] if there is en error connecting to the Workload API or
+    /// The function returns a variant of [`GrpcClientError`] if there is en error connecting to the Workload API or
     /// there is a problem processing the response.
-    pub async fn fetch_x509_context(&mut self) -> Result<X509Context, ClientError> {
+    pub async fn fetch_x509_context(&mut self) -> Result<X509Context, GrpcClientError> {
         let request = X509svidRequest::default();
 
         let grpc_stream_response: tonic::Response<tonic::Streaming<X509svidResponse>> =
@@ -336,7 +286,7 @@ impl WorkloadApiClient {
             .into_inner()
             .message()
             .await?
-            .ok_or(ClientError::EmptyResponse)?;
+            .ok_or(GrpcClientError::EmptyResponse)?;
         WorkloadApiClient::parse_x509_context_from_grpc_response(response)
     }
 
@@ -350,24 +300,22 @@ impl WorkloadApiClient {
     ///
     /// # Errors
     ///
-    /// The function returns a variant of [`ClientError`] if there is en error connecting to the Workload API or
+    /// The function returns a variant of [`GrpcClientError`] if there is en error connecting to the Workload API or
     /// there is a problem processing the response.
     ///
     /// IMPORTANT: If there's no registration entries with the requested [`SpiffeId`] mapped to the calling workload,
-    /// it will return a [`ClientError::EmptyResponse`].
+    /// it will return a [`GrpcClientError::EmptyResponse`].
     pub async fn fetch_jwt_svid<T: AsRef<str> + ToString>(
         &mut self,
         audience: &[T],
         spiffe_id: Option<&SpiffeId>,
-    ) -> Result<JwtSvid, ClientError> {
+    ) -> Result<JwtSvid, GrpcClientError> {
         let response = self.fetch_jwt(audience, spiffe_id).await?;
         response
             .svids
             .get(DEFAULT_SVID)
-            .ok_or(ClientError::EmptyResponse)
-            .and_then(|r| {
-                JwtSvid::from_str(&r.svid).map_err(ClientError::InvalidJwtSvid)
-            })
+            .ok_or(GrpcClientError::EmptyResponse)
+            .and_then(|r| JwtSvid::from_str(&r.svid).map_err(GrpcClientError::InvalidJwtSvid))
     }
 
     /// Fetches a JWT token for the given audience and [`SpiffeId`].
@@ -380,22 +328,22 @@ impl WorkloadApiClient {
     ///
     /// # Errors
     ///
-    /// The function returns a variant of [`ClientError`] if there is en error connecting to the Workload API or
+    /// The function returns a variant of [`GrpcClientError`] if there is en error connecting to the Workload API or
     /// there is a problem processing the response.
     ///
     /// IMPORTANT: If there's no registration entries with the requested [`SpiffeId`] mapped to the calling workload,
-    /// it will return a [`ClientError::EmptyResponse`].
+    /// it will return a [`GrpcClientError::EmptyResponse`].
     pub async fn fetch_jwt_token<T: AsRef<str> + ToString>(
         &mut self,
         audience: &[T],
         spiffe_id: Option<&SpiffeId>,
-    ) -> Result<String, ClientError> {
+    ) -> Result<String, GrpcClientError> {
         let response = self.fetch_jwt(audience, spiffe_id).await?;
         response
             .svids
             .get(DEFAULT_SVID)
             .map(|r| r.svid.to_string())
-            .ok_or(ClientError::EmptyResponse)
+            .ok_or(GrpcClientError::EmptyResponse)
     }
 
     /// Validates a JWT SVID token against the given audience. Returns the [`JwtSvid`] parsed from
@@ -408,13 +356,13 @@ impl WorkloadApiClient {
     ///
     /// # Errors
     ///
-    /// The function returns a variant of [`ClientError`] if there is en error connecting to the Workload API or
+    /// The function returns a variant of [`GrpcClientError`] if there is en error connecting to the Workload API or
     /// there is a problem processing the response.
     pub async fn validate_jwt_token<T: AsRef<str> + ToString>(
         &mut self,
         audience: T,
         jwt_token: &str,
-    ) -> Result<JwtSvid, ClientError> {
+    ) -> Result<JwtSvid, GrpcClientError> {
         // validate token with Workload API, the returned claims and spiffe_id are ignored as
         // they are parsed from token when the `JwtSvid` object is created, this way we avoid having
         // to validate that the response from the Workload API contains correct claims.
@@ -435,20 +383,20 @@ impl WorkloadApiClient {
     ///
     /// # Errors
     ///
-    /// The function can return an error variant of [`ClientError`] in the following scenarios:
+    /// The function can return an error variant of [`GrpcClientError`] in the following scenarios:
     ///
     /// * There's an issue connecting to the Workload API.
     /// * An error occurs while setting up the stream.
     ///
     /// Individual stream items might also be errors if there's an issue processing the response for a specific update.
-    pub async fn watch_x509_context_stream(
+    pub async fn stream_x509_contexts(
         &mut self,
-    ) -> Result<impl Stream<Item = Result<X509Context, ClientError>>, ClientError> {
+    ) -> Result<impl Stream<Item = Result<X509Context, GrpcClientError>>, GrpcClientError> {
         let request = X509svidRequest::default();
         let response = self.client.fetch_x509svid(request).await?;
         let stream = response.into_inner().map(|message| {
             message
-                .map_err(ClientError::from)
+                .map_err(GrpcClientError::from)
                 .and_then(WorkloadApiClient::parse_x509_context_from_grpc_response)
         });
         Ok(stream)
@@ -466,20 +414,20 @@ impl WorkloadApiClient {
     ///
     /// # Errors
     ///
-    /// The function can return an error variant of [`ClientError`] in the following scenarios:
+    /// The function can return an error variant of [`GrpcClientError`] in the following scenarios:
     ///
     /// * There's an issue connecting to the Workload API.
     /// * An error occurs while setting up the stream.
     ///
     /// Individual stream items might also be errors if there's an issue processing the response for a specific update.
-    pub async fn watch_x509_svid_stream(
+    pub async fn stream_x509_svids(
         &mut self,
-    ) -> Result<impl Stream<Item = Result<X509Svid, ClientError>>, ClientError> {
+    ) -> Result<impl Stream<Item = Result<X509Svid, GrpcClientError>>, GrpcClientError> {
         let request = X509svidRequest::default();
         let response = self.client.fetch_x509svid(request).await?;
         let stream = response.into_inner().map(|message| {
             message
-                .map_err(ClientError::from)
+                .map_err(GrpcClientError::from)
                 .and_then(WorkloadApiClient::parse_x509_svid_from_grpc_response)
         });
         Ok(stream)
@@ -497,20 +445,20 @@ impl WorkloadApiClient {
     ///
     /// # Errors
     ///
-    /// The function can return an error variant of [`ClientError`] in the following scenarios:
+    /// The function can return an error variant of [`GrpcClientError`] in the following scenarios:
     ///
     /// * There's an issue connecting to the Workload API.
     /// * An error occurs while setting up the stream.
     ///
     /// Individual stream items might also be errors if there's an issue processing the response for a specific update.
-    pub async fn watch_x509_bundles_stream(
+    pub async fn stream_x509_bundles(
         &mut self,
-    ) -> Result<impl Stream<Item = Result<X509BundleSet, ClientError>>, ClientError> {
+    ) -> Result<impl Stream<Item = Result<X509BundleSet, GrpcClientError>>, GrpcClientError> {
         let request = X509BundlesRequest::default();
         let response = self.client.fetch_x509_bundles(request).await?;
         let stream = response.into_inner().map(|message| {
             message
-                .map_err(ClientError::from)
+                .map_err(GrpcClientError::from)
                 .and_then(WorkloadApiClient::parse_x509_bundle_set_from_grpc_response)
         });
         Ok(stream)
@@ -528,20 +476,20 @@ impl WorkloadApiClient {
     ///
     /// # Errors
     ///
-    /// The function can return an error variant of [`ClientError`] in the following scenarios:
+    /// The function can return an error variant of [`GrpcClientError`] in the following scenarios:
     ///
     /// * There's an issue connecting to the Workload API.
     /// * An error occurs while setting up the stream.
     ///
     /// Individual stream items might also be errors if there's an issue processing the response for a specific update.
-    pub async fn watch_jwt_bundles_stream(
+    pub async fn stream_jwt_bundles(
         &mut self,
-    ) -> Result<impl Stream<Item = Result<JwtBundleSet, ClientError>>, ClientError> {
+    ) -> Result<impl Stream<Item = Result<JwtBundleSet, GrpcClientError>>, GrpcClientError> {
         let request = JwtBundlesRequest::default();
         let response = self.client.fetch_jwt_bundles(request).await?;
         let stream = response.into_inner().map(|message| {
             message
-                .map_err(ClientError::from)
+                .map_err(GrpcClientError::from)
                 .and_then(WorkloadApiClient::parse_jwt_bundle_set_from_grpc_response)
         });
         Ok(stream)
@@ -554,7 +502,7 @@ impl WorkloadApiClient {
         &mut self,
         audience: &[T],
         spiffe_id: Option<&SpiffeId>,
-    ) -> Result<JwtsvidResponse, ClientError> {
+    ) -> Result<JwtsvidResponse, GrpcClientError> {
         let request = JwtsvidRequest {
             spiffe_id: spiffe_id.map(ToString::to_string).unwrap_or_default(),
             audience: audience.iter().map(|s| s.to_string()).collect(),
@@ -567,7 +515,7 @@ impl WorkloadApiClient {
         &mut self,
         audience: T,
         jwt_svid: &str,
-    ) -> Result<ValidateJwtsvidResponse, ClientError> {
+    ) -> Result<ValidateJwtsvidResponse, GrpcClientError> {
         let request = ValidateJwtsvidRequest {
             audience: audience.as_ref().into(),
             svid: jwt_svid.into(),
@@ -578,25 +526,25 @@ impl WorkloadApiClient {
 
     fn parse_x509_svid_from_grpc_response(
         response: X509svidResponse,
-    ) -> Result<X509Svid, ClientError> {
+    ) -> Result<X509Svid, GrpcClientError> {
         let svid = response
             .svids
             .get(DEFAULT_SVID)
-            .ok_or(ClientError::EmptyResponse)?;
+            .ok_or(GrpcClientError::EmptyResponse)?;
 
         X509Svid::parse_from_der(svid.x509_svid.as_ref(), svid.x509_svid_key.as_ref())
-            .map_err(ClientError::from)
+            .map_err(GrpcClientError::from)
     }
 
     fn parse_x509_svids_from_grpc_response(
         response: X509svidResponse,
-    ) -> Result<Vec<X509Svid>, ClientError> {
+    ) -> Result<Vec<X509Svid>, GrpcClientError> {
         let mut svids_vec = Vec::new();
 
         for svid in response.svids.iter() {
             let parsed_svid =
                 X509Svid::parse_from_der(svid.x509_svid.as_ref(), svid.x509_svid_key.as_ref())
-                    .map_err(ClientError::from)?;
+                    .map_err(GrpcClientError::from)?;
 
             svids_vec.push(parsed_svid);
         }
@@ -606,13 +554,14 @@ impl WorkloadApiClient {
 
     fn parse_x509_bundle_set_from_grpc_response(
         response: X509BundlesResponse,
-    ) -> Result<X509BundleSet, ClientError> {
+    ) -> Result<X509BundleSet, GrpcClientError> {
         let bundles: Result<Vec<_>, _> = response
             .bundles
             .into_iter()
             .map(|(td, bundle_data)| {
                 let trust_domain = TrustDomain::try_from(td)?;
-                X509Bundle::parse_from_der(trust_domain, &bundle_data).map_err(ClientError::from)
+                X509Bundle::parse_from_der(trust_domain, &bundle_data)
+                    .map_err(GrpcClientError::from)
             })
             .collect();
 
@@ -626,13 +575,13 @@ impl WorkloadApiClient {
 
     fn parse_jwt_bundle_set_from_grpc_response(
         response: JwtBundlesResponse,
-    ) -> Result<JwtBundleSet, ClientError> {
+    ) -> Result<JwtBundleSet, GrpcClientError> {
         let mut bundle_set = JwtBundleSet::new();
 
         for (td, bundle_data) in response.bundles.into_iter() {
             let trust_domain = TrustDomain::try_from(td)?;
             let bundle = JwtBundle::from_jwt_authorities(trust_domain, &bundle_data)
-                .map_err(ClientError::from)?;
+                .map_err(GrpcClientError::from)?;
 
             bundle_set.add_bundle(bundle);
         }
@@ -642,20 +591,20 @@ impl WorkloadApiClient {
 
     fn parse_x509_context_from_grpc_response(
         response: X509svidResponse,
-    ) -> Result<X509Context, ClientError> {
+    ) -> Result<X509Context, GrpcClientError> {
         let mut svids = Vec::new();
         let mut bundle_set = X509BundleSet::new();
 
         for svid in response.svids.into_iter() {
             let x509_svid =
                 X509Svid::parse_from_der(svid.x509_svid.as_ref(), svid.x509_svid_key.as_ref())
-                    .map_err(ClientError::from)?;
+                    .map_err(GrpcClientError::from)?;
 
             let trust_domain = x509_svid.spiffe_id().trust_domain().clone();
             svids.push(x509_svid);
 
             let bundle = X509Bundle::parse_from_der(trust_domain, svid.bundle.as_ref())
-                .map_err(ClientError::from)?;
+                .map_err(GrpcClientError::from)?;
             bundle_set.add_bundle(bundle);
         }
 

--- a/spiffe/src/workload_api/mod.rs
+++ b/spiffe/src/workload_api/mod.rs
@@ -39,6 +39,5 @@
 //! # Ok(())
 //! # }
 //! ```
-pub mod address;
 pub mod client;
 pub mod x509_context;

--- a/spiffe/src/workload_api/x509_context.rs
+++ b/spiffe/src/workload_api/x509_context.rs
@@ -1,8 +1,8 @@
 //! Defines a type that holds all the X.509 materials for a workload (i.e. X.509 SVIDs and bundles)
 
 use crate::bundle::x509::X509BundleSet;
+use crate::constants::DEFAULT_SVID;
 use crate::svid::x509::X509Svid;
-use crate::workload_api::client::DEFAULT_SVID;
 
 /// Represents all X.509 materials fetched from the Workload API.
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/spiffe/tests/workload_api_client_test.rs
+++ b/spiffe/tests/workload_api_client_test.rs
@@ -182,7 +182,7 @@ mod integration_tests {
     }
 
     #[tokio::test]
-    async fn watch_x509_context_stream() {
+    async fn stream_x509_contexts() {
         let mut client = get_client().await;
         let test_duration = std::time::Duration::from_secs(60);
         let expected_ids = vec![&*SPIFFE_ID_1, &*SPIFFE_ID_2];
@@ -190,7 +190,7 @@ mod integration_tests {
         let result = tokio::time::timeout(test_duration, async {
             let mut update_count = 0;
             let mut stream = client
-                .watch_x509_context_stream()
+                .stream_x509_contexts()
                 .await
                 .expect("Failed to get stream");
 
@@ -234,7 +234,7 @@ mod integration_tests {
     }
 
     #[tokio::test]
-    async fn watch_x509_svid_stream() {
+    async fn stream_x509_svids() {
         let mut client = get_client().await;
         let test_duration = std::time::Duration::from_secs(60);
         let expected_ids = vec![&*SPIFFE_ID_1, &*SPIFFE_ID_2];
@@ -242,7 +242,7 @@ mod integration_tests {
         let result = tokio::time::timeout(test_duration, async {
             let mut update_count = 0;
             let mut stream = client
-                .watch_x509_svid_stream()
+                .stream_x509_svids()
                 .await
                 .expect("Failed to get stream");
 
@@ -275,13 +275,13 @@ mod integration_tests {
     }
 
     #[tokio::test]
-    async fn watch_x509_bundles_stream() {
+    async fn stream_x509_bundles() {
         let mut client = get_client().await;
         let test_duration = std::time::Duration::from_secs(60);
 
         let result = tokio::time::timeout(test_duration, async {
             let mut stream = client
-                .watch_x509_bundles_stream()
+                .stream_x509_bundles()
                 .await
                 .expect("Failed to get stream");
             if let Some(update) = stream.next().await {
@@ -308,13 +308,13 @@ mod integration_tests {
     }
 
     #[tokio::test]
-    async fn watch_jwt_bundles_stream() {
+    async fn stream_jwt_bundles() {
         let mut client = get_client().await;
         let test_duration = std::time::Duration::from_secs(60);
 
         let result = tokio::time::timeout(test_duration, async {
             let mut stream = client
-                .watch_jwt_bundles_stream()
+                .stream_jwt_bundles()
                 .await
                 .expect("Failed to get stream");
             if let Some(update) = stream.next().await {

--- a/spire-api/Cargo.toml
+++ b/spire-api/Cargo.toml
@@ -15,8 +15,8 @@ categories = ["cryptography"]
 keywords = ["SPIFFE", "SPIRE"]
 
 [dependencies]
+spiffe = { path = "../spiffe", default-features = false, features = ["spiffe-types"] }
 bytes = { version = "1", features = ["serde"] }
-spiffe = { path = "../spiffe" }
 tonic = { version = "0.9", default-features = false, features = ["prost", "codegen", "transport"]}
 prost = { version = "0.11"}
 prost-types = {version = "0.11"}

--- a/spire-api/tests/delegated_identity_api_client_test.rs
+++ b/spire-api/tests/delegated_identity_api_client_test.rs
@@ -1,17 +1,17 @@
-// These tests requires a running SPIRE server and agent with workloads registered (see script `ci.sh`).
+// These tests requires a running SPIRE server and agent with workloads registered (see script `scripts/run-spire.sh`).
 // In addition it requires the admin endpoint to be exposed, and the running user to registered
 // as an authorized_delegate.
 
 #[cfg(feature = "integration-tests")]
 mod integration_tests {
     use once_cell::sync::Lazy;
-    use spiffe::bundle::BundleRefSource;
     use spiffe::bundle::jwt::JwtBundleSet;
+    use spiffe::bundle::BundleRefSource;
     use spiffe::spiffe_id::TrustDomain;
+    use spire_api::agent::delegated_identity::DelegatedIdentityClient;
     use spire_api::selectors;
     use std::process::Command;
     use tokio_stream::StreamExt;
-    use spire_api::agent::delegated_identity::DelegatedIdentityClient;
 
     static TRUST_DOMAIN: Lazy<TrustDomain> = Lazy::new(|| TrustDomain::new("example.org").unwrap());
 
@@ -122,10 +122,7 @@ mod integration_tests {
             .expect("Failed to get bundle");
     }
 
-    async fn verify_jwt(
-        client: &mut DelegatedIdentityClient,
-        bundles: JwtBundleSet,
-    ) {
+    async fn verify_jwt(client: &mut DelegatedIdentityClient, bundles: JwtBundleSet) {
         let svids = client
             .fetch_jwt_svids(
                 &["my_audience"],
@@ -157,7 +154,6 @@ mod integration_tests {
             .await
             .expect("Failed to fetch trust bundles");
 
-
         verify_jwt(&mut client, response).await;
     }
 
@@ -174,6 +170,10 @@ mod integration_tests {
             .await
             .expect("Test did not complete in the expected duration");
 
-        verify_jwt(&mut client, result.expect("empty result").expect("error in stream")).await;
+        verify_jwt(
+            &mut client,
+            result.expect("empty result").expect("error in stream"),
+        )
+        .await;
     }
 }


### PR DESCRIPTION
This PR refactors the `spiffe` crate by dividing its functionality into two main features: `spiffe-types` and `workload-api`.

### Changes:
- **spiffe-types**: This feature includes definitions and basic utilities for handling SPIFFE types.
- **workload-api**: This feature encompasses the client functionality for interacting with the Workload API, including the protobuf code.

### Other improvements:
- The `spire-api` crate now depends only on the `spiffe-types` feature.
- The streaming methods in the Workload API client have been renamed to align with the client in the `spire-api` crate. The methods now follow the pattern: `stream_{object_type}` for better consistency.
- Constants and errors have been moved to their own packages.
