### PR TITLE
Improvement in cert validation

### DIFF
--- a/spiffe/src/cert/errors.rs
+++ b/spiffe/src/cert/errors.rs
@@ -11,6 +11,10 @@ pub enum CertificateError {
     #[error("X.509 extension is missing: {0}")]
     MissingX509Extension(String),
 
+    /// Unexpected X.509 extension encountered.
+    #[error("unexpected X.509 extension: {0}")]
+    UnexpectedExtension(String),
+
     /// Error returned by the ASN.1/DER processing library.
     #[error("failed decoding chain of DER certificates")]
     ChainDecode(#[from] ASN1DecodeErr),


### PR DESCRIPTION
## Summary

This pull request introduces improvements to the `find_spiffe_id` function in the code related to X.509 certificates. The changes remove unreachable code and enhance error handling for unexpected X.509 extension scenarios.

## Changes Made

- Removed the `unreachable!()` statement from the `find_spiffe_id` function in the `validations.rs` module. The statement was replaced with a new error variant `UnexpectedExtension` to handle unexpected X.509 extension cases.
- Updated the `find_spiffe_id` function to use the new error variant when an unexpected extension is encountered while parsing the Subject Alternative Name (SAN) extension.

These changes not only remove unreachable code but also improve the error reporting and handling.
