### PR TITLE
Make log Dependency Optional and Associate with workload-api Feature

### DIFF
--- a/spiffe/Cargo.toml
+++ b/spiffe/Cargo.toml
@@ -28,7 +28,6 @@ serde_json = "1.0"
 zeroize = { version = "1.6", features = ["zeroize_derive"] }
 time = "0.3"
 tonic = "0.9"
-log = "0.4"
 
 # workload-api dependencies:
 prost = { version = "0.11", optional = true }
@@ -37,6 +36,7 @@ tokio = { version = "1", features = ["net", "test-util"], optional = true }
 tokio-stream = { version = "0.1", optional = true }
 tower = { version = "0.4", features = ["util"], optional = true }
 tokio-util = {version = "0.7", optional = true }
+log = {version = "0.4", optional = true }
 
 [dev-dependencies]
 jsonwebkey = { version = "0.3", features = ["generate"] }
@@ -55,5 +55,5 @@ anyhow = "1.0.65"
 [features]
 default = ["spiffe-types", "workload-api"]
 spiffe-types = []
-workload-api = ["prost", "prost-types", "tokio", "tokio-stream", "tower", "tokio-util"]
+workload-api = ["prost", "prost-types", "tokio", "tokio-stream", "tower", "tokio-util", "log"]
 integration-tests = []


### PR DESCRIPTION
This PR adjusts the `log` dependency in the `Cargo.toml` file, making it optional and associating it specifically with the `workload-api` feature. 