### PR TITLE
Pin version of `spiffe` dependency in `spire-api` crate for publishing compliance

### DIFF
--- a/spire-api/Cargo.toml
+++ b/spire-api/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["cryptography"]
 keywords = ["SPIFFE", "SPIRE"]
 
 [dependencies]
-spiffe = { path = "../spiffe", default-features = false, features = ["spiffe-types"] }
+spiffe = { version = "0.4.0", default-features = false, features = ["spiffe-types"] }
 bytes = { version = "1", features = ["serde"] }
 tonic = { version = "0.9", default-features = false, features = ["prost", "codegen", "transport"]}
 prost = { version = "0.11"}
@@ -34,3 +34,6 @@ anyhow = "1.0.65"
 
 [features]
 integration-tests = []
+
+[patch.crates-io]
+spiffe = { path = "../spiffe" }


### PR DESCRIPTION
This PR addresses the requirement that all dependencies must have a version specified when publishing a crate. It sets the `spiffe` dependency in the `spire-api` crate to the latest published version `0.4.0`, and includes a patch to use the local path for development, aligning with both local development needs and publishing requirements.