### PR TITLE
Clone `spire-api-sdk` in `build.rs` if Not Present

### DIFF
--- a/spire-api/build.rs
+++ b/spire-api/build.rs
@@ -1,4 +1,22 @@
-fn main() -> Result<(), anyhow::Error> {
+use std::path::Path;
+use std::process::Command;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let destination = Path::new("../spire-api-sdk");
+    if !destination.exists() {
+        let status = Command::new("git")
+            .args(&[
+                "clone",
+                "https://github.com/spiffe/spire-api-sdk.git",
+                destination.to_str().unwrap(),
+            ])
+            .status()?;
+
+        if !status.success() {
+            return Err("Failed to clone repository".into());
+        }
+    }
+
     let mut proto_config = prost_build::Config::new();
     proto_config.bytes(["."]);
     tonic_build::configure()

--- a/spire-api/build.rs
+++ b/spire-api/build.rs
@@ -1,6 +1,8 @@
 use std::path::Path;
 use std::process::Command;
 
+const SPIRE_API_SDK_TAG: &str = "v1.7.2";
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let destination = Path::new("../spire-api-sdk");
     if !destination.exists() {
@@ -15,6 +17,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         if !status.success() {
             return Err("Failed to clone repository".into());
         }
+
+        // Checkout the specific tag
+        let status = Command::new("git")
+            .current_dir(destination)
+            .args(&["checkout", SPIRE_API_SDK_TAG])
+            .status()?;
+
+        if !status.success() {
+            return Err("Failed to checkout tag".into());
+        }
     }
 
     let mut proto_config = prost_build::Config::new();
@@ -25,7 +37,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .compile_with_config(
             proto_config,
             &["../spire-api-sdk/proto/spire/api/agent/delegatedidentity/v1/delegatedidentity.proto"],
-            &["../spire-api-sdk/proto"], 
+            &["../spire-api-sdk/proto"],
         )?;
 
     Ok(())


### PR DESCRIPTION
This PR modifies the `build.rs` file in the `spire-api` crate to clone the `spire-api-sdk` repository if the destination directory does not already exist. This change ensures that the necessary proto files are available during the publishing process.