### PR TITLE
Update Dependencies In `spiffe` Crate

### DIFF
--- a/spiffe/Cargo.toml
+++ b/spiffe/Cargo.toml
@@ -16,22 +16,22 @@ keywords = ["SPIFFE", "X509", "JWT"]
 
 [dependencies]
 # spiffe-types dependencies:
-thiserror = "1.0"
-url = "2.2"
+thiserror = "1"
+url = "2"
 asn1 = { package = "simple_asn1", version = "0.6" }
-x509-parser = "0.15"
+x509-parser = "0.16"
 pkcs8 = "0.10"
-jsonwebtoken = "8.3"
+jsonwebtoken = "8"
 jsonwebkey = { version = "0.3", features = ["jsonwebtoken", "jwt-convert"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-zeroize = { version = "1.6", features = ["zeroize_derive"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+zeroize = { version = "1", features = ["zeroize_derive"] }
 time = "0.3"
-tonic = "0.9"
+tonic = "0.11"
 
 # workload-api dependencies:
-prost = { version = "0.11", optional = true }
-prost-types = { version = "0.11", optional = true }
+prost = { version = "0.12", optional = true }
+prost-types = { version = "0.12", optional = true }
 tokio = { version = "1", features = ["net", "test-util"], optional = true }
 tokio-stream = { version = "0.1", optional = true }
 tower = { version = "0.4", features = ["util"], optional = true }
@@ -41,16 +41,16 @@ log = {version = "0.4", optional = true }
 [dev-dependencies]
 jsonwebkey = { version = "0.3", features = ["generate"] }
 tokio-test = "0.4"
-once_cell = "1.18"
+once_cell = "1"
 
 # used to verify in tests that the certificates bytes from the X.509 SVIDs and bundle authorities
 # are parseable as OpenSSL X.509 certificates.
 openssl = { version = "0.10", features = ["vendored"] }
 
 [build-dependencies]
-tonic-build = { version = "0.9", default-features = false, features = ["prost"] }
-prost-build = "0.11"
-anyhow = "1.0.65"
+tonic-build = { version = "0.11", default-features = false, features = ["prost"] }
+prost-build = "0.12"
+anyhow = "1"
 
 [features]
 default = ["spiffe-types", "workload-api"]

--- a/spiffe/Cargo.toml
+++ b/spiffe/Cargo.toml
@@ -32,7 +32,7 @@ tonic = "0.11"
 # workload-api dependencies:
 prost = { version = "0.12", optional = true }
 prost-types = { version = "0.12", optional = true }
-tokio = { version = "1", features = ["net", "test-util"], optional = true }
+tokio = { version = "1", features = ["net"], optional = true }
 tokio-stream = { version = "0.1", optional = true }
 tower = { version = "0.4", features = ["util"], optional = true }
 tokio-util = {version = "0.7", optional = true }
@@ -40,7 +40,7 @@ log = {version = "0.4", optional = true }
 
 [dev-dependencies]
 jsonwebkey = { version = "0.3", features = ["generate"] }
-tokio-test = "0.4"
+tokio = { version = "1", features = ["macros"] }
 once_cell = "1"
 
 # used to verify in tests that the certificates bytes from the X.509 SVIDs and bundle authorities

--- a/spiffe/src/proto/workload.rs
+++ b/spiffe/src/proto/workload.rs
@@ -365,7 +365,7 @@ pub mod spiffe_workload_api_server {
     #[async_trait]
     pub trait SpiffeWorkloadApi: Send + Sync + 'static {
         /// Server streaming response type for the FetchX509SVID method.
-        type FetchX509SVIDStream: futures_core::Stream<
+        type FetchX509SVIDStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::X509svidResponse, tonic::Status>,
             >
             + Send
@@ -382,7 +382,7 @@ pub mod spiffe_workload_api_server {
             tonic::Status,
         >;
         /// Server streaming response type for the FetchX509Bundles method.
-        type FetchX509BundlesStream: futures_core::Stream<
+        type FetchX509BundlesStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::X509BundlesResponse, tonic::Status>,
             >
             + Send
@@ -406,7 +406,7 @@ pub mod spiffe_workload_api_server {
             request: tonic::Request<super::JwtsvidRequest>,
         ) -> std::result::Result<tonic::Response<super::JwtsvidResponse>, tonic::Status>;
         /// Server streaming response type for the FetchJWTBundles method.
-        type FetchJWTBundlesStream: futures_core::Stream<
+        type FetchJWTBundlesStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::JwtBundlesResponse, tonic::Status>,
             >
             + Send
@@ -529,7 +529,8 @@ pub mod spiffe_workload_api_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).fetch_x509svid(request).await
+                                <T as SpiffeWorkloadApi>::fetch_x509svid(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -576,7 +577,11 @@ pub mod spiffe_workload_api_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).fetch_x509_bundles(request).await
+                                <T as SpiffeWorkloadApi>::fetch_x509_bundles(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -622,7 +627,8 @@ pub mod spiffe_workload_api_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).fetch_jwtsvid(request).await
+                                <T as SpiffeWorkloadApi>::fetch_jwtsvid(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -669,7 +675,8 @@ pub mod spiffe_workload_api_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).fetch_jwt_bundles(request).await
+                                <T as SpiffeWorkloadApi>::fetch_jwt_bundles(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -715,7 +722,8 @@ pub mod spiffe_workload_api_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).validate_jwtsvid(request).await
+                                <T as SpiffeWorkloadApi>::validate_jwtsvid(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }


### PR DESCRIPTION
Updated `prost`, `prost-types`, `tonic-build`, `prost-build`, and additional dependencies in the `spiffe` crate and regenerated protobuf code. `spire-api` crate updates will follow after `spiffe` crate release.