### PR TITLE
Update `spire-api` dependencies

### DIFF
--- a/spire-api/Cargo.toml
+++ b/spire-api/Cargo.toml
@@ -15,25 +15,22 @@ categories = ["cryptography"]
 keywords = ["SPIFFE", "SPIRE"]
 
 [dependencies]
-spiffe = { version = "0.4.0", default-features = false, features = ["spiffe-types"] }
+spiffe = { version = "0.4.0", path = "../spiffe", default-features = false, features = ["spiffe-types"] }
 bytes = { version = "1", features = ["serde"] }
-tonic = { version = "0.9", default-features = false, features = ["prost", "codegen", "transport"]}
-prost = { version = "0.11"}
-prost-types = {version = "0.11"}
-tokio = { "version" = "1", features = ["net", "test-util"]}
+tonic = { version = "0.11", default-features = false, features = ["prost", "codegen", "transport"]}
+prost = { version = "0.12"}
+prost-types = {version = "0.12"}
+tokio = { "version" = "1", features = ["net"]}
 tokio-stream = "0.1"
 tower = { version = "0.4", features = ["util"] }
 
 [dev-dependencies]
-once_cell = "1.18"
+once_cell = "1"
 
 [build-dependencies]
-tonic-build = { version = "0.9", default-features = false, features = ["prost"] }
-prost-build = "0.11"
-anyhow = "1.0.65"
+tonic-build = { version = "0.11", default-features = false, features = ["prost"] }
+prost-build = "0.12"
+anyhow = "1"
 
 [features]
 integration-tests = []
-
-[patch.crates-io]
-spiffe = { path = "../spiffe" }

--- a/spire-api/src/proto/spire.api.agent.delegatedidentity.v1.rs
+++ b/spire-api/src/proto/spire.api.agent.delegatedidentity.v1.rs
@@ -307,7 +307,7 @@ pub mod delegated_identity_server {
     #[async_trait]
     pub trait DelegatedIdentity: Send + Sync + 'static {
         /// Server streaming response type for the SubscribeToX509SVIDs method.
-        type SubscribeToX509SVIDsStream: futures_core::Stream<
+        type SubscribeToX509SVIDsStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<
                     super::SubscribeToX509sviDsResponse,
                     tonic::Status,
@@ -325,7 +325,7 @@ pub mod delegated_identity_server {
             tonic::Status,
         >;
         /// Server streaming response type for the SubscribeToX509Bundles method.
-        type SubscribeToX509BundlesStream: futures_core::Stream<
+        type SubscribeToX509BundlesStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<
                     super::SubscribeToX509BundlesResponse,
                     tonic::Status,
@@ -352,7 +352,7 @@ pub mod delegated_identity_server {
             tonic::Status,
         >;
         /// Server streaming response type for the SubscribeToJWTBundles method.
-        type SubscribeToJWTBundlesStream: futures_core::Stream<
+        type SubscribeToJWTBundlesStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<
                     super::SubscribeToJwtBundlesResponse,
                     tonic::Status,
@@ -478,7 +478,11 @@ pub mod delegated_identity_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).subscribe_to_x509svi_ds(request).await
+                                <T as DelegatedIdentity>::subscribe_to_x509svi_ds(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -526,7 +530,11 @@ pub mod delegated_identity_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).subscribe_to_x509_bundles(request).await
+                                <T as DelegatedIdentity>::subscribe_to_x509_bundles(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -572,7 +580,8 @@ pub mod delegated_identity_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).fetch_jwtsvi_ds(request).await
+                                <T as DelegatedIdentity>::fetch_jwtsvi_ds(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -620,7 +629,11 @@ pub mod delegated_identity_server {
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                (*inner).subscribe_to_jwt_bundles(request).await
+                                <T as DelegatedIdentity>::subscribe_to_jwt_bundles(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }

--- a/spire-api/src/proto/spire.api.types.rs
+++ b/spire-api/src/proto/spire.api.types.rs
@@ -38,11 +38,11 @@ pub mod selector_match {
         /// candidate selectors, independent of ordering.
         /// Example:
         ///    Given:
-        ///      - 'e1 { Selectors: ["a:1", "b:2", "c:3"]}'
-        ///      - 'e2 { Selectors: ["a:1", "b:2"]}'
+        ///      - 'e1 { Selectors: \["a:1", "b:2", "c:3"\]}'
+        ///      - 'e2 { Selectors: \["a:1", "b:2"\]}'
         ///      - 'e3 { Selectors: \["a:1"\]}'
         ///    Operation:
-        ///      - MATCH_EXACT ["a:1", "b:2"]
+        ///      - MATCH_EXACT \["a:1", "b:2"\]
         ///    Entries that match:
         ///      - 'e2'
         MatchExact = 0,
@@ -50,8 +50,8 @@ pub mod selector_match {
         /// of the provided set of selectors will match.
         /// Example:
         ///    Given:
-        ///      - 'e1 { Selectors: ["a:1", "b:2", "c:3"]}'
-        ///      - 'e2 { Selectors: ["a:1", "b:2"]}'
+        ///      - 'e1 { Selectors: \["a:1", "b:2", "c:3"\]}'
+        ///      - 'e2 { Selectors: \["a:1", "b:2"\]}'
         ///      - 'e3 { Selectors: \["a:1"\]}'
         ///    Operation:
         ///      - MATCH_SUBSET \["a:1"\]
@@ -62,11 +62,11 @@ pub mod selector_match {
         /// of the provided selectors will match.
         /// Example:
         ///    Given:
-        ///      - 'e1 { Selectors: ["a:1", "b:2", "c:3"]}'
-        ///      - 'e2 { Selectors: ["a:1", "b:2"]}'
+        ///      - 'e1 { Selectors: \["a:1", "b:2", "c:3"\]}'
+        ///      - 'e2 { Selectors: \["a:1", "b:2"\]}'
         ///      - 'e3 { Selectors: \["a:1"\]}'
         ///    Operation:
-        ///      - MATCH_SUPERSET ["a:1", "b:2"]
+        ///      - MATCH_SUPERSET \["a:1", "b:2"\]
         ///    Entries that match:
         ///      - 'e1'
         ///      - 'e2'
@@ -75,8 +75,8 @@ pub mod selector_match {
         /// of the provided set of selectors will match.
         /// Example:
         ///    Given:
-        ///      - 'e1 { Selectors: ["a:1", "b:2", "c:3"]}'
-        ///      - 'e2 { Selectors: ["a:1", "b:2"]}'
+        ///      - 'e1 { Selectors: \["a:1", "b:2", "c:3"\]}'
+        ///      - 'e2 { Selectors: \["a:1", "b:2"\]}'
         ///      - 'e3 { Selectors: \["a:1"\]}'
         ///    Operation:
         ///      - MATCH_ANY \["a:1"\]


### PR DESCRIPTION
Updated `prost`, `prost-types`, `tonic-build`, `prost-build`, and additional dependencies in the `spire-apire` crate and regenerated protobuf code.

Added the `path` field to the `spiffe` dependency to enable direct integration of local changes for easier development and testing.