### PR TITLE
Add Publish Workflow. Pin Actions Versions Using SHA Hashes

### DIFF
--- a/.github/actions/setup-env/action.yaml
+++ b/.github/actions/setup-env/action.yaml
@@ -6,19 +6,9 @@ runs:
     - name: Install Protoc
       uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b  #v3.0.0
 
-    - name: Cache Rust dependencies
-      uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-
-
     - name: Setup Rust toolchain
       uses: actions-rs/toolchain@4d3830945c2fde0cba21123066096384613b8558  # v1.0.6
       with:
-        toolchain: nightly
+        profile: minimal
+        toolchain: stable
         components: rustfmt, clippy

--- a/.github/actions/setup-env/action.yaml
+++ b/.github/actions/setup-env/action.yaml
@@ -9,8 +9,6 @@ runs:
   steps:
     - name: Install Protoc
       uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b  #v3.0.0
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Setup Rust toolchain
       uses: actions-rs/toolchain@4d3830945c2fde0cba21123066096384613b8558  # v1.0.6

--- a/.github/actions/setup-env/action.yaml
+++ b/.github/actions/setup-env/action.yaml
@@ -1,5 +1,9 @@
 name: 'Setup Environment'
 description: 'Install Protoc and Rust toolchain, and set up Rust dependencies cache'
+inputs:
+  github_token:
+    description: 'GitHub Token for authentication'
+    required: true
 runs:
   using: 'composite'
   steps:

--- a/.github/actions/setup-env/action.yaml
+++ b/.github/actions/setup-env/action.yaml
@@ -5,6 +5,8 @@ runs:
   steps:
     - name: Install Protoc
       uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b  #v3.0.0
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Setup Rust toolchain
       uses: actions-rs/toolchain@4d3830945c2fde0cba21123066096384613b8558  # v1.0.6

--- a/.github/actions/setup-env/action.yaml
+++ b/.github/actions/setup-env/action.yaml
@@ -10,9 +10,18 @@ runs:
     - name: Install Protoc
       uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b  #v3.0.0
 
-    - name: Setup Rust toolchain
+    - name: Setup Rust stable toolchain
       uses: actions-rs/toolchain@4d3830945c2fde0cba21123066096384613b8558  # v1.0.6
       with:
         profile: minimal
         toolchain: stable
-        components: rustfmt, clippy
+        default: true
+        components: clippy
+
+    - name: Setup Rust nightly toolchain
+      uses: actions-rs/toolchain@4d3830945c2fde0cba21123066096384613b8558  # v1.0.6
+      with:
+        profile: minimal
+        toolchain: nightly
+        components: rustfmt
+        override: false

--- a/.github/actions/setup-env/action.yaml
+++ b/.github/actions/setup-env/action.yaml
@@ -18,7 +18,7 @@ runs:
           ${{ runner.os }}-cargo-
 
     - name: Setup Rust toolchain
-      uses: actions-rs/toolchain@4d3830945c2fde0cba21123066096384613b8558  # v1.06
+      uses: actions-rs/toolchain@4d3830945c2fde0cba21123066096384613b8558  # v1.0.6
       with:
         toolchain: nightly
         components: rustfmt, clippy

--- a/.github/actions/setup-env/action.yaml
+++ b/.github/actions/setup-env/action.yaml
@@ -4,10 +4,10 @@ runs:
   using: 'composite'
   steps:
     - name: Install Protoc
-      uses: arduino/setup-protoc@v2
+      uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b  #v3.0.0
 
     - name: Cache Rust dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
       with:
         path: |
           ~/.cargo/registry
@@ -18,7 +18,7 @@ runs:
           ${{ runner.os }}-cargo-
 
     - name: Setup Rust toolchain
-      uses: actions-rs/toolchain@v1
+      uses: actions-rs/toolchain@4d3830945c2fde0cba21123066096384613b8558  # v1.06
       with:
         toolchain: nightly
         components: rustfmt, clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Continuous Integration
 on: [push, pull_request]
 
 jobs:
-  lint-and-setup:
+  setup-and-lint:
     name: Setup and Lint Rust Code
     runs-on: ubuntu-latest
     steps:
@@ -11,52 +11,36 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: recursive
+      - name: Install toolchain
+        uses: ./.github/actions/setup-env
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Cache Project
         uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84  # v2.7.3
 
-      - name: Install dependencies and common setup
-        uses: ./.github/actions/setup-env
       - name: Lint Rust code with rustfmt and clippy
         run: |
           cargo fmt
           cargo clippy
 
-  build:
-    name: Build Rust Project
+  build-and-test:
+    name: Build and Test Rust Project
     runs-on: ubuntu-latest
-    needs: lint-and-setup
+    needs: setup-and-lint
     steps:
       - name: Check out code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: recursive
-      - name: Cache Project
-        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84  # v2.7.3
-
-      - name: Install dependencies and common setup
-        uses: ./.github/actions/setup-env
-      - name: Build Rust project
-        run: cargo build
-
-  test:
-    name: Run spiffe and spire-api Integration Tests
-    runs-on: ubuntu-latest
-    env:
-      SPIFFE_ENDPOINT_SOCKET: unix:/tmp/spire-agent/public/api.sock
-      SPIRE_ADMIN_ENDPOINT_SOCKET: unix:/tmp/spire-agent/admin/api.sock
-    needs: build
-    steps:
-      - name: Check out code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          submodules: recursive
-      - name: Cache Project
-        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84  # v2.7.3
-
       - name: Install toolchain
         uses: ./.github/actions/setup-env
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Cache Project
+        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84  # v2.7.3
+
+      - name: Build Rust project
+        run: cargo build
 
       - name: Start SPIRE
         run: ./scripts/run-spire.sh &

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
     name: Build and Test Rust Project
     runs-on: ubuntu-latest
     needs: setup-and-lint
+    env:
+      SPIFFE_ENDPOINT_SOCKET: unix:/tmp/spire-agent/public/api.sock
+      SPIRE_ADMIN_ENDPOINT_SOCKET: unix:/tmp/spire-agent/admin/api.sock
     steps:
       - name: Check out code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: recursive
+      - name: Cache Project
+        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84  # v2.7.3
       - name: Install toolchain
         uses: ./.github/actions/setup-env
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Cache Project
-        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84  # v2.7.3
 
       - name: Lint Rust code with rustfmt and clippy
         run: |
@@ -35,12 +35,12 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: recursive
+      - name: Cache Project
+        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84  # v2.7.3
       - name: Install toolchain
         uses: ./.github/actions/setup-env
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Cache Project
-        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84  # v2.7.3
 
       - name: Build Rust project
         run: cargo build
@@ -48,13 +48,8 @@ jobs:
       - name: Start SPIRE
         run: ./scripts/run-spire.sh &
 
-      - name: Execute spiffe Integration Tests
+      - name: Run Integration Tests
         run: RUST_BACKTRACE=1 cargo test --features integration-tests
-        working-directory: spiffe
-
-      - name: Execute spire-api Integration Tests
-        run: RUST_BACKTRACE=1 cargo test --features integration-tests
-        working-directory: spire-api
 
       - name: Clean up SPIRE
         run: ./scripts/cleanup-spire.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
 
       - name: Install toolchain
         uses: ./.github/actions/setup-env
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Project
         uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84  # v2.7.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Lint Rust code with rustfmt and clippy
         run: |
-          cargo fmt
+          cargo +nightly fmt
           cargo clippy
 
   build-and-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: recursive
       - name: Install dependencies and common setup
@@ -24,7 +24,7 @@ jobs:
     needs: lint-and-setup
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: recursive
       - name: Install dependencies and common setup
@@ -41,7 +41,7 @@ jobs:
     needs: build
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: recursive
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: recursive
+      - name: Cache Project
+        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84  # v2.7.3
+
       - name: Install dependencies and common setup
         uses: ./.github/actions/setup-env
       - name: Lint Rust code with rustfmt and clippy
@@ -27,6 +30,9 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: recursive
+      - name: Cache Project
+        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84  # v2.7.3
+
       - name: Install dependencies and common setup
         uses: ./.github/actions/setup-env
       - name: Build Rust project
@@ -44,14 +50,13 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: recursive
+      - name: Cache Project
+        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84  # v2.7.3
 
       - name: Install toolchain
         uses: ./.github/actions/setup-env
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Cache Project
-        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84  # v2.7.3
 
       - name: Start SPIRE
         run: ./scripts/run-spire.sh &

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,11 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install dependencies and common setup
+      - name: Install toolchain
         uses: ./.github/actions/setup-env
+
+      - name: Cache Project
+        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84  # v2.7.3
 
       - name: Start SPIRE
         run: ./scripts/run-spire.sh &

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
         uses: ./.github/actions/setup-env
       - name: Lint Rust code with rustfmt and clippy
         run: |
-          cargo +nightly fmt
-          cargo +nightly clippy
+          cargo fmt
+          cargo clippy
 
   build:
     name: Build Rust Project

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,8 +12,12 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: recursive
-      - name: Install dependencies and common setup
+
+      - name: Install toolchain
         uses: ./.github/actions/setup-env
+
+      - name: Cache Project
+        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84  # v2.7.3
 
       - name: Cargo Login
         run: cargo login ${{ secrets.CRATES_IO_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Publish Crates
+
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          submodules: recursive
+      - name: Install dependencies and common setup
+        uses: ./.github/actions/setup-env
+
+      - name: Cargo Login
+        run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
+
+      # Conditional step for spiffe crate
+      - name: Publish spiffe
+        if: startsWith(github.ref, 'refs/tags/spiffe-')
+        run: |
+          cd spiffe
+          cargo publish
+      # Conditional step for spire-api crate
+      - name: Publish spire-api
+        if: startsWith(github.ref, 'refs/tags/spire-api-')
+        run: |
+          cd spire-api
+          cargo publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Install toolchain
         uses: ./.github/actions/setup-env
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Project
         uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84  # v2.7.3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,14 +12,12 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: recursive
-
+      - name: Cache Project
+        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84  # v2.7.3
       - name: Install toolchain
         uses: ./.github/actions/setup-env
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Cache Project
-        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84  # v2.7.3
 
       - name: Cargo Login
         run: cargo login ${{ secrets.CRATES_IO_TOKEN }}

--- a/spiffe/src/proto/workload.rs
+++ b/spiffe/src/proto/workload.rs
@@ -20,8 +20,10 @@ pub struct X509svidResponse {
     /// the workload should trust, keyed by the SPIFFE ID of the foreign trust
     /// domain. Bundles are ASN.1 DER encoded.
     #[prost(map = "string, bytes", tag = "3")]
-    pub federated_bundles:
-        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::bytes::Bytes>,
+    pub federated_bundles: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        ::prost::bytes::Bytes,
+    >,
 }
 /// The X509SVID message carries a single SVID and all associated information,
 /// including the X.509 bundle for the trust domain.
@@ -59,7 +61,10 @@ pub struct X509BundlesResponse {
     /// workload should trust, keyed by the SPIFFE ID of the trust domain.
     /// Bundles are ASN.1 DER encoded.
     #[prost(map = "string, bytes", tag = "2")]
-    pub bundles: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::bytes::Bytes>,
+    pub bundles: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        ::prost::bytes::Bytes,
+    >,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -103,7 +108,10 @@ pub struct JwtBundlesResponse {
     /// Required. JWK encoded JWT bundles, keyed by the SPIFFE ID of the trust
     /// domain.
     #[prost(map = "string, bytes", tag = "1")]
-    pub bundles: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::bytes::Bytes>,
+    pub bundles: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        ::prost::bytes::Bytes,
+    >,
 }
 /// The ValidateJWTSVIDRequest message conveys request parameters for
 /// JWT-SVID validation.
@@ -135,8 +143,8 @@ pub struct ValidateJwtsvidResponse {
 /// Generated client implementations.
 pub mod spiffe_workload_api_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct SpiffeWorkloadApiClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -169,8 +177,9 @@ pub mod spiffe_workload_api_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
         {
             SpiffeWorkloadApiClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -216,14 +225,19 @@ pub mod spiffe_workload_api_client {
             tonic::Response<tonic::codec::Streaming<super::X509svidResponse>>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/SpiffeWorkloadAPI/FetchX509SVID");
+            let path = http::uri::PathAndQuery::from_static(
+                "/SpiffeWorkloadAPI/FetchX509SVID",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("SpiffeWorkloadAPI", "FetchX509SVID"));
@@ -240,14 +254,19 @@ pub mod spiffe_workload_api_client {
             tonic::Response<tonic::codec::Streaming<super::X509BundlesResponse>>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/SpiffeWorkloadAPI/FetchX509Bundles");
+            let path = http::uri::PathAndQuery::from_static(
+                "/SpiffeWorkloadAPI/FetchX509Bundles",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("SpiffeWorkloadAPI", "FetchX509Bundles"));
@@ -259,15 +278,23 @@ pub mod spiffe_workload_api_client {
         pub async fn fetch_jwtsvid(
             &mut self,
             request: impl tonic::IntoRequest<super::JwtsvidRequest>,
-        ) -> std::result::Result<tonic::Response<super::JwtsvidResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::JwtsvidResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/SpiffeWorkloadAPI/FetchJWTSVID");
+            let path = http::uri::PathAndQuery::from_static(
+                "/SpiffeWorkloadAPI/FetchJWTSVID",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("SpiffeWorkloadAPI", "FetchJWTSVID"));
@@ -283,14 +310,19 @@ pub mod spiffe_workload_api_client {
             tonic::Response<tonic::codec::Streaming<super::JwtBundlesResponse>>,
             tonic::Status,
         > {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/SpiffeWorkloadAPI/FetchJWTBundles");
+            let path = http::uri::PathAndQuery::from_static(
+                "/SpiffeWorkloadAPI/FetchJWTBundles",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("SpiffeWorkloadAPI", "FetchJWTBundles"));
@@ -301,16 +333,23 @@ pub mod spiffe_workload_api_client {
         pub async fn validate_jwtsvid(
             &mut self,
             request: impl tonic::IntoRequest<super::ValidateJwtsvidRequest>,
-        ) -> std::result::Result<tonic::Response<super::ValidateJwtsvidResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::ValidateJwtsvidResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/SpiffeWorkloadAPI/ValidateJWTSVID");
+            let path = http::uri::PathAndQuery::from_static(
+                "/SpiffeWorkloadAPI/ValidateJWTSVID",
+            );
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("SpiffeWorkloadAPI", "ValidateJWTSVID"));
@@ -328,7 +367,8 @@ pub mod spiffe_workload_api_server {
         /// Server streaming response type for the FetchX509SVID method.
         type FetchX509SVIDStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::X509svidResponse, tonic::Status>,
-            > + Send
+            >
+            + Send
             + 'static;
         /// Fetch X.509-SVIDs for all SPIFFE identities the workload is entitled to,
         /// as well as related information like trust bundles and CRLs. As this
@@ -337,11 +377,15 @@ pub mod spiffe_workload_api_server {
         async fn fetch_x509svid(
             &self,
             request: tonic::Request<super::X509svidRequest>,
-        ) -> std::result::Result<tonic::Response<Self::FetchX509SVIDStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::FetchX509SVIDStream>,
+            tonic::Status,
+        >;
         /// Server streaming response type for the FetchX509Bundles method.
         type FetchX509BundlesStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::X509BundlesResponse, tonic::Status>,
-            > + Send
+            >
+            + Send
             + 'static;
         /// Fetch trust bundles and CRLs. Useful for clients that only need to
         /// validate SVIDs without obtaining an SVID for themself. As this
@@ -350,7 +394,10 @@ pub mod spiffe_workload_api_server {
         async fn fetch_x509_bundles(
             &self,
             request: tonic::Request<super::X509BundlesRequest>,
-        ) -> std::result::Result<tonic::Response<Self::FetchX509BundlesStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::FetchX509BundlesStream>,
+            tonic::Status,
+        >;
         /// Fetch JWT-SVIDs for all SPIFFE identities the workload is entitled to,
         /// for the requested audience. If an optional SPIFFE ID is requested, only
         /// the JWT-SVID for that SPIFFE ID is returned.
@@ -361,7 +408,8 @@ pub mod spiffe_workload_api_server {
         /// Server streaming response type for the FetchJWTBundles method.
         type FetchJWTBundlesStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::JwtBundlesResponse, tonic::Status>,
-            > + Send
+            >
+            + Send
             + 'static;
         /// Fetches the JWT bundles, formatted as JWKS documents, keyed by the
         /// SPIFFE ID of the trust domain. As this information changes, subsequent
@@ -369,13 +417,19 @@ pub mod spiffe_workload_api_server {
         async fn fetch_jwt_bundles(
             &self,
             request: tonic::Request<super::JwtBundlesRequest>,
-        ) -> std::result::Result<tonic::Response<Self::FetchJWTBundlesStream>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<Self::FetchJWTBundlesStream>,
+            tonic::Status,
+        >;
         /// Validates a JWT-SVID against the requested audience. Returns the SPIFFE
         /// ID of the JWT-SVID and JWT claims.
         async fn validate_jwtsvid(
             &self,
             request: tonic::Request<super::ValidateJwtsvidRequest>,
-        ) -> std::result::Result<tonic::Response<super::ValidateJwtsvidResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ValidateJwtsvidResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct SpiffeWorkloadApiServer<T: SpiffeWorkloadApi> {
@@ -400,7 +454,10 @@ pub mod spiffe_workload_api_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -456,21 +513,24 @@ pub mod spiffe_workload_api_server {
                 "/SpiffeWorkloadAPI/FetchX509SVID" => {
                     #[allow(non_camel_case_types)]
                     struct FetchX509SVIDSvc<T: SpiffeWorkloadApi>(pub Arc<T>);
-                    impl<T: SpiffeWorkloadApi>
-                        tonic::server::ServerStreamingService<super::X509svidRequest>
-                        for FetchX509SVIDSvc<T>
-                    {
+                    impl<
+                        T: SpiffeWorkloadApi,
+                    > tonic::server::ServerStreamingService<super::X509svidRequest>
+                    for FetchX509SVIDSvc<T> {
                         type Response = super::X509svidResponse;
                         type ResponseStream = T::FetchX509SVIDStream;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::X509svidRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SpiffeWorkloadApi>::fetch_x509svid(&inner, request).await
+                                <T as SpiffeWorkloadApi>::fetch_x509svid(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -501,21 +561,27 @@ pub mod spiffe_workload_api_server {
                 "/SpiffeWorkloadAPI/FetchX509Bundles" => {
                     #[allow(non_camel_case_types)]
                     struct FetchX509BundlesSvc<T: SpiffeWorkloadApi>(pub Arc<T>);
-                    impl<T: SpiffeWorkloadApi>
-                        tonic::server::ServerStreamingService<super::X509BundlesRequest>
-                        for FetchX509BundlesSvc<T>
-                    {
+                    impl<
+                        T: SpiffeWorkloadApi,
+                    > tonic::server::ServerStreamingService<super::X509BundlesRequest>
+                    for FetchX509BundlesSvc<T> {
                         type Response = super::X509BundlesResponse;
                         type ResponseStream = T::FetchX509BundlesStream;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::X509BundlesRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SpiffeWorkloadApi>::fetch_x509_bundles(&inner, request).await
+                                <T as SpiffeWorkloadApi>::fetch_x509_bundles(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -546,18 +612,23 @@ pub mod spiffe_workload_api_server {
                 "/SpiffeWorkloadAPI/FetchJWTSVID" => {
                     #[allow(non_camel_case_types)]
                     struct FetchJWTSVIDSvc<T: SpiffeWorkloadApi>(pub Arc<T>);
-                    impl<T: SpiffeWorkloadApi> tonic::server::UnaryService<super::JwtsvidRequest>
-                        for FetchJWTSVIDSvc<T>
-                    {
+                    impl<
+                        T: SpiffeWorkloadApi,
+                    > tonic::server::UnaryService<super::JwtsvidRequest>
+                    for FetchJWTSVIDSvc<T> {
                         type Response = super::JwtsvidResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::JwtsvidRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SpiffeWorkloadApi>::fetch_jwtsvid(&inner, request).await
+                                <T as SpiffeWorkloadApi>::fetch_jwtsvid(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -588,21 +659,24 @@ pub mod spiffe_workload_api_server {
                 "/SpiffeWorkloadAPI/FetchJWTBundles" => {
                     #[allow(non_camel_case_types)]
                     struct FetchJWTBundlesSvc<T: SpiffeWorkloadApi>(pub Arc<T>);
-                    impl<T: SpiffeWorkloadApi>
-                        tonic::server::ServerStreamingService<super::JwtBundlesRequest>
-                        for FetchJWTBundlesSvc<T>
-                    {
+                    impl<
+                        T: SpiffeWorkloadApi,
+                    > tonic::server::ServerStreamingService<super::JwtBundlesRequest>
+                    for FetchJWTBundlesSvc<T> {
                         type Response = super::JwtBundlesResponse;
                         type ResponseStream = T::FetchJWTBundlesStream;
-                        type Future =
-                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::JwtBundlesRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SpiffeWorkloadApi>::fetch_jwt_bundles(&inner, request).await
+                                <T as SpiffeWorkloadApi>::fetch_jwt_bundles(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -633,19 +707,23 @@ pub mod spiffe_workload_api_server {
                 "/SpiffeWorkloadAPI/ValidateJWTSVID" => {
                     #[allow(non_camel_case_types)]
                     struct ValidateJWTSVIDSvc<T: SpiffeWorkloadApi>(pub Arc<T>);
-                    impl<T: SpiffeWorkloadApi>
-                        tonic::server::UnaryService<super::ValidateJwtsvidRequest>
-                        for ValidateJWTSVIDSvc<T>
-                    {
+                    impl<
+                        T: SpiffeWorkloadApi,
+                    > tonic::server::UnaryService<super::ValidateJwtsvidRequest>
+                    for ValidateJWTSVIDSvc<T> {
                         type Response = super::ValidateJwtsvidResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ValidateJwtsvidRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SpiffeWorkloadApi>::validate_jwtsvid(&inner, request).await
+                                <T as SpiffeWorkloadApi>::validate_jwtsvid(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -673,14 +751,18 @@ pub mod spiffe_workload_api_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    Ok(http::Response::builder()
-                        .status(200)
-                        .header("grpc-status", "12")
-                        .header("content-type", "application/grpc")
-                        .body(empty_body())
-                        .unwrap())
-                }),
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
             }
         }
     }
@@ -706,7 +788,8 @@ pub mod spiffe_workload_api_server {
             write!(f, "{:?}", self.0)
         }
     }
-    impl<T: SpiffeWorkloadApi> tonic::server::NamedService for SpiffeWorkloadApiServer<T> {
+    impl<T: SpiffeWorkloadApi> tonic::server::NamedService
+    for SpiffeWorkloadApiServer<T> {
         const NAME: &'static str = "SpiffeWorkloadAPI";
     }
 }

--- a/spiffe/src/proto/workload.rs
+++ b/spiffe/src/proto/workload.rs
@@ -20,10 +20,8 @@ pub struct X509svidResponse {
     /// the workload should trust, keyed by the SPIFFE ID of the foreign trust
     /// domain. Bundles are ASN.1 DER encoded.
     #[prost(map = "string, bytes", tag = "3")]
-    pub federated_bundles: ::std::collections::HashMap<
-        ::prost::alloc::string::String,
-        ::prost::bytes::Bytes,
-    >,
+    pub federated_bundles:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::bytes::Bytes>,
 }
 /// The X509SVID message carries a single SVID and all associated information,
 /// including the X.509 bundle for the trust domain.
@@ -61,10 +59,7 @@ pub struct X509BundlesResponse {
     /// workload should trust, keyed by the SPIFFE ID of the trust domain.
     /// Bundles are ASN.1 DER encoded.
     #[prost(map = "string, bytes", tag = "2")]
-    pub bundles: ::std::collections::HashMap<
-        ::prost::alloc::string::String,
-        ::prost::bytes::Bytes,
-    >,
+    pub bundles: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::bytes::Bytes>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -108,10 +103,7 @@ pub struct JwtBundlesResponse {
     /// Required. JWK encoded JWT bundles, keyed by the SPIFFE ID of the trust
     /// domain.
     #[prost(map = "string, bytes", tag = "1")]
-    pub bundles: ::std::collections::HashMap<
-        ::prost::alloc::string::String,
-        ::prost::bytes::Bytes,
-    >,
+    pub bundles: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::bytes::Bytes>,
 }
 /// The ValidateJWTSVIDRequest message conveys request parameters for
 /// JWT-SVID validation.
@@ -143,8 +135,8 @@ pub struct ValidateJwtsvidResponse {
 /// Generated client implementations.
 pub mod spiffe_workload_api_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
     use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
     #[derive(Debug, Clone)]
     pub struct SpiffeWorkloadApiClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -177,9 +169,8 @@ pub mod spiffe_workload_api_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + Send + Sync,
         {
             SpiffeWorkloadApiClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -225,19 +216,14 @@ pub mod spiffe_workload_api_client {
             tonic::Response<tonic::codec::Streaming<super::X509svidResponse>>,
             tonic::Status,
         > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/SpiffeWorkloadAPI/FetchX509SVID",
-            );
+            let path = http::uri::PathAndQuery::from_static("/SpiffeWorkloadAPI/FetchX509SVID");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("SpiffeWorkloadAPI", "FetchX509SVID"));
@@ -254,19 +240,14 @@ pub mod spiffe_workload_api_client {
             tonic::Response<tonic::codec::Streaming<super::X509BundlesResponse>>,
             tonic::Status,
         > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/SpiffeWorkloadAPI/FetchX509Bundles",
-            );
+            let path = http::uri::PathAndQuery::from_static("/SpiffeWorkloadAPI/FetchX509Bundles");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("SpiffeWorkloadAPI", "FetchX509Bundles"));
@@ -278,23 +259,15 @@ pub mod spiffe_workload_api_client {
         pub async fn fetch_jwtsvid(
             &mut self,
             request: impl tonic::IntoRequest<super::JwtsvidRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::JwtsvidResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::JwtsvidResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/SpiffeWorkloadAPI/FetchJWTSVID",
-            );
+            let path = http::uri::PathAndQuery::from_static("/SpiffeWorkloadAPI/FetchJWTSVID");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("SpiffeWorkloadAPI", "FetchJWTSVID"));
@@ -310,19 +283,14 @@ pub mod spiffe_workload_api_client {
             tonic::Response<tonic::codec::Streaming<super::JwtBundlesResponse>>,
             tonic::Status,
         > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/SpiffeWorkloadAPI/FetchJWTBundles",
-            );
+            let path = http::uri::PathAndQuery::from_static("/SpiffeWorkloadAPI/FetchJWTBundles");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("SpiffeWorkloadAPI", "FetchJWTBundles"));
@@ -333,23 +301,16 @@ pub mod spiffe_workload_api_client {
         pub async fn validate_jwtsvid(
             &mut self,
             request: impl tonic::IntoRequest<super::ValidateJwtsvidRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ValidateJwtsvidResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::ValidateJwtsvidResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/SpiffeWorkloadAPI/ValidateJWTSVID",
-            );
+            let path = http::uri::PathAndQuery::from_static("/SpiffeWorkloadAPI/ValidateJWTSVID");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("SpiffeWorkloadAPI", "ValidateJWTSVID"));
@@ -367,8 +328,7 @@ pub mod spiffe_workload_api_server {
         /// Server streaming response type for the FetchX509SVID method.
         type FetchX509SVIDStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::X509svidResponse, tonic::Status>,
-            >
-            + Send
+            > + Send
             + 'static;
         /// Fetch X.509-SVIDs for all SPIFFE identities the workload is entitled to,
         /// as well as related information like trust bundles and CRLs. As this
@@ -377,15 +337,11 @@ pub mod spiffe_workload_api_server {
         async fn fetch_x509svid(
             &self,
             request: tonic::Request<super::X509svidRequest>,
-        ) -> std::result::Result<
-            tonic::Response<Self::FetchX509SVIDStream>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<Self::FetchX509SVIDStream>, tonic::Status>;
         /// Server streaming response type for the FetchX509Bundles method.
         type FetchX509BundlesStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::X509BundlesResponse, tonic::Status>,
-            >
-            + Send
+            > + Send
             + 'static;
         /// Fetch trust bundles and CRLs. Useful for clients that only need to
         /// validate SVIDs without obtaining an SVID for themself. As this
@@ -394,10 +350,7 @@ pub mod spiffe_workload_api_server {
         async fn fetch_x509_bundles(
             &self,
             request: tonic::Request<super::X509BundlesRequest>,
-        ) -> std::result::Result<
-            tonic::Response<Self::FetchX509BundlesStream>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<Self::FetchX509BundlesStream>, tonic::Status>;
         /// Fetch JWT-SVIDs for all SPIFFE identities the workload is entitled to,
         /// for the requested audience. If an optional SPIFFE ID is requested, only
         /// the JWT-SVID for that SPIFFE ID is returned.
@@ -408,8 +361,7 @@ pub mod spiffe_workload_api_server {
         /// Server streaming response type for the FetchJWTBundles method.
         type FetchJWTBundlesStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::JwtBundlesResponse, tonic::Status>,
-            >
-            + Send
+            > + Send
             + 'static;
         /// Fetches the JWT bundles, formatted as JWKS documents, keyed by the
         /// SPIFFE ID of the trust domain. As this information changes, subsequent
@@ -417,19 +369,13 @@ pub mod spiffe_workload_api_server {
         async fn fetch_jwt_bundles(
             &self,
             request: tonic::Request<super::JwtBundlesRequest>,
-        ) -> std::result::Result<
-            tonic::Response<Self::FetchJWTBundlesStream>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<Self::FetchJWTBundlesStream>, tonic::Status>;
         /// Validates a JWT-SVID against the requested audience. Returns the SPIFFE
         /// ID of the JWT-SVID and JWT claims.
         async fn validate_jwtsvid(
             &self,
             request: tonic::Request<super::ValidateJwtsvidRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ValidateJwtsvidResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::ValidateJwtsvidResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct SpiffeWorkloadApiServer<T: SpiffeWorkloadApi> {
@@ -454,10 +400,7 @@ pub mod spiffe_workload_api_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -513,24 +456,21 @@ pub mod spiffe_workload_api_server {
                 "/SpiffeWorkloadAPI/FetchX509SVID" => {
                     #[allow(non_camel_case_types)]
                     struct FetchX509SVIDSvc<T: SpiffeWorkloadApi>(pub Arc<T>);
-                    impl<
-                        T: SpiffeWorkloadApi,
-                    > tonic::server::ServerStreamingService<super::X509svidRequest>
-                    for FetchX509SVIDSvc<T> {
+                    impl<T: SpiffeWorkloadApi>
+                        tonic::server::ServerStreamingService<super::X509svidRequest>
+                        for FetchX509SVIDSvc<T>
+                    {
                         type Response = super::X509svidResponse;
                         type ResponseStream = T::FetchX509SVIDStream;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::ResponseStream>,
-                            tonic::Status,
-                        >;
+                        type Future =
+                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::X509svidRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SpiffeWorkloadApi>::fetch_x509svid(&inner, request)
-                                    .await
+                                <T as SpiffeWorkloadApi>::fetch_x509svid(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -561,27 +501,21 @@ pub mod spiffe_workload_api_server {
                 "/SpiffeWorkloadAPI/FetchX509Bundles" => {
                     #[allow(non_camel_case_types)]
                     struct FetchX509BundlesSvc<T: SpiffeWorkloadApi>(pub Arc<T>);
-                    impl<
-                        T: SpiffeWorkloadApi,
-                    > tonic::server::ServerStreamingService<super::X509BundlesRequest>
-                    for FetchX509BundlesSvc<T> {
+                    impl<T: SpiffeWorkloadApi>
+                        tonic::server::ServerStreamingService<super::X509BundlesRequest>
+                        for FetchX509BundlesSvc<T>
+                    {
                         type Response = super::X509BundlesResponse;
                         type ResponseStream = T::FetchX509BundlesStream;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::ResponseStream>,
-                            tonic::Status,
-                        >;
+                        type Future =
+                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::X509BundlesRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SpiffeWorkloadApi>::fetch_x509_bundles(
-                                        &inner,
-                                        request,
-                                    )
-                                    .await
+                                <T as SpiffeWorkloadApi>::fetch_x509_bundles(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -612,23 +546,18 @@ pub mod spiffe_workload_api_server {
                 "/SpiffeWorkloadAPI/FetchJWTSVID" => {
                     #[allow(non_camel_case_types)]
                     struct FetchJWTSVIDSvc<T: SpiffeWorkloadApi>(pub Arc<T>);
-                    impl<
-                        T: SpiffeWorkloadApi,
-                    > tonic::server::UnaryService<super::JwtsvidRequest>
-                    for FetchJWTSVIDSvc<T> {
+                    impl<T: SpiffeWorkloadApi> tonic::server::UnaryService<super::JwtsvidRequest>
+                        for FetchJWTSVIDSvc<T>
+                    {
                         type Response = super::JwtsvidResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::JwtsvidRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SpiffeWorkloadApi>::fetch_jwtsvid(&inner, request)
-                                    .await
+                                <T as SpiffeWorkloadApi>::fetch_jwtsvid(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -659,24 +588,21 @@ pub mod spiffe_workload_api_server {
                 "/SpiffeWorkloadAPI/FetchJWTBundles" => {
                     #[allow(non_camel_case_types)]
                     struct FetchJWTBundlesSvc<T: SpiffeWorkloadApi>(pub Arc<T>);
-                    impl<
-                        T: SpiffeWorkloadApi,
-                    > tonic::server::ServerStreamingService<super::JwtBundlesRequest>
-                    for FetchJWTBundlesSvc<T> {
+                    impl<T: SpiffeWorkloadApi>
+                        tonic::server::ServerStreamingService<super::JwtBundlesRequest>
+                        for FetchJWTBundlesSvc<T>
+                    {
                         type Response = super::JwtBundlesResponse;
                         type ResponseStream = T::FetchJWTBundlesStream;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::ResponseStream>,
-                            tonic::Status,
-                        >;
+                        type Future =
+                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::JwtBundlesRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SpiffeWorkloadApi>::fetch_jwt_bundles(&inner, request)
-                                    .await
+                                <T as SpiffeWorkloadApi>::fetch_jwt_bundles(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -707,23 +633,19 @@ pub mod spiffe_workload_api_server {
                 "/SpiffeWorkloadAPI/ValidateJWTSVID" => {
                     #[allow(non_camel_case_types)]
                     struct ValidateJWTSVIDSvc<T: SpiffeWorkloadApi>(pub Arc<T>);
-                    impl<
-                        T: SpiffeWorkloadApi,
-                    > tonic::server::UnaryService<super::ValidateJwtsvidRequest>
-                    for ValidateJWTSVIDSvc<T> {
+                    impl<T: SpiffeWorkloadApi>
+                        tonic::server::UnaryService<super::ValidateJwtsvidRequest>
+                        for ValidateJWTSVIDSvc<T>
+                    {
                         type Response = super::ValidateJwtsvidResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ValidateJwtsvidRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as SpiffeWorkloadApi>::validate_jwtsvid(&inner, request)
-                                    .await
+                                <T as SpiffeWorkloadApi>::validate_jwtsvid(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -751,18 +673,14 @@ pub mod spiffe_workload_api_server {
                     };
                     Box::pin(fut)
                 }
-                _ => {
-                    Box::pin(async move {
-                        Ok(
-                            http::Response::builder()
-                                .status(200)
-                                .header("grpc-status", "12")
-                                .header("content-type", "application/grpc")
-                                .body(empty_body())
-                                .unwrap(),
-                        )
-                    })
-                }
+                _ => Box::pin(async move {
+                    Ok(http::Response::builder()
+                        .status(200)
+                        .header("grpc-status", "12")
+                        .header("content-type", "application/grpc")
+                        .body(empty_body())
+                        .unwrap())
+                }),
             }
         }
     }
@@ -788,8 +706,7 @@ pub mod spiffe_workload_api_server {
             write!(f, "{:?}", self.0)
         }
     }
-    impl<T: SpiffeWorkloadApi> tonic::server::NamedService
-    for SpiffeWorkloadApiServer<T> {
+    impl<T: SpiffeWorkloadApi> tonic::server::NamedService for SpiffeWorkloadApiServer<T> {
         const NAME: &'static str = "SpiffeWorkloadAPI";
     }
 }


### PR DESCRIPTION
This PR enhances the automation by introducing a new GitHub Workflow for automatic publishing of crates to `crates.io`. 

Key improvements include:

- Security Enhancements: pinned action versions using their SHA hashes.
- Toolchain Standardization: using the stable Rust toolchain.
- CI Workflow Optimization: simplifications and improvements, reduced CI run times—cutting down from approximately 5 minutes to just 1.5 minutes. 