### PR TITLE
Resolve Clippy Warnings and Format Issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
 
       - name: Lint Rust code with rustfmt and clippy
         run: |
-          cargo +nightly fmt
-          cargo clippy
+          cargo +nightly fmt -- --check
+          cargo clippy -- -D warnings
 
   build-and-test:
     name: Build and Test Rust Project

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -4,3 +4,7 @@ imports_granularity = "Module"
 format_code_in_doc_comments = true
 format_macro_bodies = true
 format_strings = true
+
+ignore = [
+    "**/proto/**/*.rs",
+]

--- a/spiffe/src/proto/mod.rs
+++ b/spiffe/src/proto/mod.rs
@@ -1,1 +1,2 @@
+#![allow(clippy::all)]
 pub(crate) mod workload;

--- a/spiffe/src/spiffe_id/mod.rs
+++ b/spiffe/src/spiffe_id/mod.rs
@@ -99,7 +99,7 @@ impl SpiffeId {
         }
 
         let rest = &id[SCHEME_PREFIX.len()..];
-        let i = rest.find('/').unwrap_or_else(|| rest.len());
+        let i = rest.find('/').unwrap_or(rest.len());
 
         if i == 0 {
             return Err(SpiffeIdError::MissingTrustDomain);
@@ -214,10 +214,10 @@ pub fn validate_path(path: &str) -> Result<(), SpiffeIdError> {
         return Err(SpiffeIdError::Empty);
     }
 
-    let mut chars = path.char_indices().peekable();
+    let chars = path.char_indices().peekable();
     let mut segment_start = 0;
 
-    while let Some((idx, c)) = chars.next() {
+    for (idx, c) in chars {
         if c == '/' {
             match &path[segment_start..idx] {
                 "/" => return Err(SpiffeIdError::EmptySegment),
@@ -573,7 +573,6 @@ mod spiffe_id_tests {
 
 #[cfg(test)]
 mod trust_domain_tests {
-
     use super::*;
     use std::str::FromStr;
 

--- a/spiffe/src/svid/x509/mod.rs
+++ b/spiffe/src/svid/x509/mod.rs
@@ -92,7 +92,7 @@ impl X509Svid {
     ) -> Result<Self, X509SvidError> {
         let cert_chain = to_certificate_vec(cert_chain_der)?;
 
-        let leaf = match cert_chain.get(0) {
+        let leaf = match cert_chain.first() {
             None => return Err(X509SvidError::EmptyChain),
             Some(c) => c,
         };

--- a/spiffe/src/workload_api/client.rs
+++ b/spiffe/src/workload_api/client.rs
@@ -2,16 +2,17 @@
 //! # Examples
 //!
 //! ```no_run
-//! use tokio_stream::StreamExt;
-//! use std::error::Error;
-//! use spiffe::workload_api::client::WorkloadApiClient;
 //! use spiffe::bundle::x509::X509BundleSet;
 //! use spiffe::svid::x509::X509Svid;
+//! use spiffe::workload_api::client::WorkloadApiClient;
 //! use spiffe::workload_api::x509_context::X509Context;
+//! use std::error::Error;
+//! use tokio_stream::StreamExt;
 //!
 //! # async fn example() -> Result<(), Box< dyn Error>> {
 //!
-//! let mut client = WorkloadApiClient::new_from_path("unix:/tmp/spire-agent/public/api.sock").await?;
+//! let mut client =
+//!     WorkloadApiClient::new_from_path("unix:/tmp/spire-agent/public/api.sock").await?;
 //!
 //! let target_audience = &["service1", "service2"];
 //! // fetch a jwt token for the default identity with the target audience
@@ -65,10 +66,11 @@ use tokio_stream::{Stream, StreamExt};
 
 use crate::constants::DEFAULT_SVID;
 use crate::error::GrpcClientError;
+use crate::proto::workload::spiffe_workload_api_client::SpiffeWorkloadApiClient;
 use crate::proto::workload::{
-    spiffe_workload_api_client::SpiffeWorkloadApiClient, JwtBundlesRequest, JwtBundlesResponse,
-    JwtsvidRequest, JwtsvidResponse, ValidateJwtsvidRequest, ValidateJwtsvidResponse,
-    X509BundlesRequest, X509BundlesResponse, X509svidRequest, X509svidResponse,
+    JwtBundlesRequest, JwtBundlesResponse, JwtsvidRequest, JwtsvidResponse, ValidateJwtsvidRequest,
+    ValidateJwtsvidResponse, X509BundlesRequest, X509BundlesResponse, X509svidRequest,
+    X509svidResponse,
 };
 use tonic::transport::{Endpoint, Uri};
 use tower::service_fn;

--- a/spiffe/src/workload_api/mod.rs
+++ b/spiffe/src/workload_api/mod.rs
@@ -3,7 +3,7 @@
 //! # Examples
 //!
 //! ```no_run
-//!
+//! 
 //! use std::error::Error;
 //! use spiffe::workload_api::client::WorkloadApiClient;
 //!

--- a/spiffe/src/workload_api/x509_source.rs
+++ b/spiffe/src/workload_api/x509_source.rs
@@ -25,8 +25,14 @@
 //! let source = X509Source::default().await?;
 //! let svid = source.get_svid()?;
 //! let trust_domain = TrustDomain::new("example.org").unwrap();
-//! let bundle = source.get_bundle_for_trust_domain(&trust_domain)
-//!     .map_err(|e| format!("Failed to get bundle for trust domain {}: {}", trust_domain, e))?;
+//! let bundle = source
+//!     .get_bundle_for_trust_domain(&trust_domain)
+//!     .map_err(|e| {
+//!         format!(
+//!             "Failed to get bundle for trust domain {}: {}",
+//!             trust_domain, e
+//!         )
+//!     })?;
 //!
 //! # Ok(())
 //! # }
@@ -78,7 +84,7 @@ use tokio_util::sync::CancellationToken;
 ///
 /// impl SvidPicker for SecondSvidPicker {
 ///     fn pick_svid<'a>(&self, svids: &'a [X509Svid]) -> Option<&'a X509Svid> {
-///         svids.get(1)  // return second svid
+///         svids.get(1) // return second svid
 ///     }
 /// }
 /// ```
@@ -151,27 +157,26 @@ pub struct X509SourceBuilder {
 /// # Example
 ///
 /// ```no_run
-/// use std::error::Error;
-/// use spiffe::workload_api::client::WorkloadApiClient;
-/// use spiffe::workload_api::x509_source::X509SourceBuilder;
 /// use spiffe::svid::x509::X509Svid;
-/// use spiffe::workload_api::x509_source::SvidPicker;
+/// use spiffe::workload_api::client::WorkloadApiClient;
+/// use spiffe::workload_api::x509_source::{SvidPicker, X509SourceBuilder};
+/// use std::error::Error;
 ///
 /// struct SecondSvidPicker;
 ///
 /// impl SvidPicker for SecondSvidPicker {
 ///     fn pick_svid<'a>(&self, svids: &'a [X509Svid]) -> Option<&'a X509Svid> {
-///         svids.get(1)  // return second svid
+///         svids.get(1) // return second svid
 ///     }
 /// }
 ///
 /// # async fn example() -> Result<(), Box< dyn Error>> {
 /// let client = WorkloadApiClient::default().await?;
 /// let source = X509SourceBuilder::new()
-///    .with_client(client)
-///    .with_picker(Box::new(SecondSvidPicker))
-///    .build()
-///    .await?;
+///     .with_client(client)
+///     .with_picker(Box::new(SecondSvidPicker))
+///     .build()
+///     .await?;
 ///
 /// # Ok(())
 /// # }

--- a/spire-api/build.rs
+++ b/spire-api/build.rs
@@ -12,7 +12,10 @@ fn main() -> Result<(), anyhow::Error> {
             .out_dir("src/proto")
             .compile_with_config(
                 proto_config,
-                &["spire-api-sdk/proto/spire/api/agent/delegatedidentity/v1/delegatedidentity.proto"],
+                &[
+                    "spire-api-sdk/proto/spire/api/agent/delegatedidentity/v1/delegatedidentity.\
+                     proto",
+                ],
                 &["spire-api-sdk/proto"],
             )?;
     } else {

--- a/spire-api/src/agent/delegated_identity.rs
+++ b/spire-api/src/agent/delegated_identity.rs
@@ -6,8 +6,8 @@
 //! Most importantly, this API cannot be used over the standard endpoint, it must be used over the admin socket.
 //! The admin socket can be configured in the SPIRE agent configuration document.
 
+use crate::proto::spire::api::agent::delegatedidentity::v1::delegated_identity_client::DelegatedIdentityClient as DelegatedIdentityApiClient;
 use crate::proto::spire::api::agent::delegatedidentity::v1::{
-    delegated_identity_client::DelegatedIdentityClient as DelegatedIdentityApiClient,
     FetchJwtsviDsRequest, SubscribeToJwtBundlesRequest, SubscribeToJwtBundlesResponse,
     SubscribeToX509BundlesRequest, SubscribeToX509BundlesResponse, SubscribeToX509sviDsRequest,
     SubscribeToX509sviDsResponse,

--- a/spire-api/src/agent/mod.rs
+++ b/spire-api/src/agent/mod.rs
@@ -6,5 +6,4 @@
 //!
 //! # Note
 //! Access these APIs via the `admin_socket_path` in the [agent configuration file](https://spiffe.io/docs/latest/deploying/spire_agent/#agent-configuration-file).
-//!
 pub mod delegated_identity;

--- a/spire-api/src/proto/mod.rs
+++ b/spire-api/src/proto/mod.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 pub mod spire {
     pub mod api {
         pub mod agent {


### PR DESCRIPTION
Resolved existing Clippy warnings and formatting discrepancies, and incorporated enforcement mechanisms into our CI workflow to maintain code quality standards automatically. This update includes running `cargo +nightly fmt -- --check` to ensure code formatting aligns with Rust's style guidelines, and `cargo clippy -- -D warnings` to treat all Clippy warnings as errors.