### PR TITLE
Add Test for Parsing JWKS with Empty Keys Array

### DIFF
--- a/spiffe/src/bundle/jwt/mod.rs
+++ b/spiffe/src/bundle/jwt/mod.rs
@@ -264,6 +264,9 @@ mod jwt_bundle_test {
         let jwt_bundle = JwtBundle::from_jwt_authorities(trust_domain, bundle_bytes)
             .expect("Failed to parse JWKS with empty keys array");
 
-        assert!(jwt_bundle.jwt_authorities.is_empty(), "JWT authorities should be empty");
+        assert!(
+            jwt_bundle.jwt_authorities.is_empty(),
+            "JWT authorities should be empty"
+        );
     }
 }

--- a/spiffe/src/bundle/jwt/mod.rs
+++ b/spiffe/src/bundle/jwt/mod.rs
@@ -256,4 +256,14 @@ mod jwt_bundle_test {
             JwtBundleError::Deserialize(..)
         ));
     }
+
+    #[test]
+    fn test_parse_jwks_with_empty_keys_array() {
+        let bundle_bytes = r#"{"keys": []}"#.as_bytes();
+        let trust_domain = TrustDomain::new("domain.test").unwrap();
+        let jwt_bundle = JwtBundle::from_jwt_authorities(trust_domain, bundle_bytes)
+            .expect("Failed to parse JWKS with empty keys array");
+
+        assert!(jwt_bundle.jwt_authorities.is_empty(), "JWT authorities should be empty");
+    }
 }


### PR DESCRIPTION
### Description:

Introduces a unit test for JwtBundle::from_jwt_authorities to verify correct handling of JWKS documents with an empty keys array, ensuring our parsing logic robustly accommodates such edge cases without errors. This addition bolsters the reliability of our JWKS processing against unusual but valid JWKS configurations.