### PR TITLE
Since we explicitly depend on 0.12.3 due to use of non-deprecated method sigs, require it explicitly

### DIFF
--- a/spiffe/Cargo.toml
+++ b/spiffe/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 zeroize = { version = "1", features = ["zeroize_derive"] }
 time = "0.3"
-tonic = "0.12"
+tonic = "0.12.3"
 
 # workload-api dependencies:
 prost = { version = "0.13", optional = true }
@@ -48,7 +48,7 @@ once_cell = "1"
 openssl = { version = "0.10", features = ["vendored"] }
 
 [build-dependencies]
-tonic-build = { version = "0.12", default-features = false, features = ["prost"] }
+tonic-build = { version = "0.12.3", default-features = false, features = ["prost"] }
 prost-build = "0.13"
 anyhow = "1"
 

--- a/spire-api/Cargo.toml
+++ b/spire-api/Cargo.toml
@@ -17,7 +17,7 @@ keywords = ["SPIFFE", "SPIRE"]
 [dependencies]
 spiffe = { version = "0.6.2", path = "../spiffe", default-features = false, features = ["spiffe-types"] }
 bytes = { version = "1", features = ["serde"] }
-tonic = { version = "0.12", default-features = false, features = ["prost", "codegen", "transport"]}
+tonic = { version = "0.12.3", default-features = false, features = ["prost", "codegen", "transport"]}
 prost = { version = "0.13"}
 prost-types = {version = "0.13"}
 tokio = { "version" = "1", features = ["net"]}
@@ -30,7 +30,7 @@ tokio = { version = "1", features = ["macros"] }
 once_cell = "1"
 
 [build-dependencies]
-tonic-build = { version = "0.12.2", default-features = false, features = ["prost"] }
+tonic-build = { version = "0.12.3", default-features = false, features = ["prost"] }
 prost-build = "0.13"
 anyhow = "1"
 


### PR DESCRIPTION
As a side effect of https://github.com/maxlambrecht/rust-spiffe/pull/115, updated `tonic`/`tonic-build` to 0.12.3 to fix a lint fail around deprecated method signatures (`compile_with_config` to `compile_protos_with_config`)

However I did not forcibly require _at-least_ 0.12.3 in the `Cargo.toml`, which is not ideal.