### PR TITLE
Use protox to avoid the need to have protoc installed

### DIFF
--- a/spiffe/Cargo.toml
+++ b/spiffe/Cargo.toml
@@ -48,6 +48,7 @@ once_cell = "1"
 openssl = { version = "0.10", features = ["vendored"] }
 
 [build-dependencies]
+protox = "0.7.2"
 tonic-build = { version = "0.12.3", default-features = false, features = ["prost"] }
 prost-build = "0.13"
 anyhow = "1"

--- a/spiffe/build.rs
+++ b/spiffe/build.rs
@@ -7,14 +7,11 @@ fn main() -> Result<(), anyhow::Error> {
     if !is_docs_rs {
         let mut proto_config = prost_build::Config::new();
         proto_config.bytes(["."]);
+        let file_descriptors = protox::compile(["src/proto/workload.proto"], ["src/proto"])?;
         tonic_build::configure()
             .build_client(true)
             .out_dir("src/proto")
-            .compile_protos_with_config(
-                proto_config,
-                &["src/proto/workload.proto"],
-                &["src/proto"],
-            )?;
+            .compile_fds_with_config(proto_config, file_descriptors)?;
 
         fs::rename("src/proto/_.rs", "src/proto/workload.rs")?;
     } else {

--- a/spire-api/Cargo.toml
+++ b/spire-api/Cargo.toml
@@ -32,6 +32,7 @@ once_cell = "1"
 [build-dependencies]
 tonic-build = { version = "0.12.3", default-features = false, features = ["prost"] }
 prost-build = "0.13"
+protox = "0.7.2"
 anyhow = "1"
 
 [features]

--- a/spire-api/build.rs
+++ b/spire-api/build.rs
@@ -7,17 +7,14 @@ fn main() -> Result<(), anyhow::Error> {
     if !is_docs_rs {
         let mut proto_config = prost_build::Config::new();
         proto_config.bytes(["."]);
+        let file_descriptors = protox::compile(
+            ["spire-api-sdk/proto/spire/api/agent/delegatedidentity/v1/delegatedidentity.proto"],
+            ["spire-api-sdk/proto"],
+        )?;
         tonic_build::configure()
             .build_client(true)
             .out_dir("src/proto")
-            .compile_protos_with_config(
-                proto_config,
-                &[
-                    "spire-api-sdk/proto/spire/api/agent/delegatedidentity/v1/delegatedidentity.\
-                     proto",
-                ],
-                &["spire-api-sdk/proto"],
-            )?;
+            .compile_fds_with_config(proto_config, file_descriptors)?;
     } else {
         println!("cargo:warning=Skipping protobuf code generation on docs.rs.");
     }


### PR DESCRIPTION
With the current setup every user needs the protobuf compiler installed to use the spiffe crate. This PR removes this dependency by using protox instead. 

From the [protox](https://crates.io/crates/protox) README 
> protox

> An implementation of the protobuf compiler in rust, intended for use as a library with crates such as [prost-build](https://crates.io/crates/prost-build) to avoid needing to build protoc.