### PR TITLE
Update protox dependency

### DIFF
--- a/spiffe/Cargo.toml
+++ b/spiffe/Cargo.toml
@@ -48,7 +48,7 @@ once_cell = "1"
 openssl = { version = "0.10", features = ["vendored"] }
 
 [build-dependencies]
-protox = "0.7.2"
+protox = "0.8.0"
 tonic-build = { version = "0.13.0", default-features = false, features = ["prost"] }
 prost-build = "0.13"
 anyhow = "1"

--- a/spire-api/Cargo.toml
+++ b/spire-api/Cargo.toml
@@ -31,7 +31,7 @@ once_cell = "1"
 [build-dependencies]
 tonic-build = { version = "0.13.0", default-features = false, features = ["prost"] }
 prost-build = "0.13"
-protox = "0.7.2"
+protox = "0.8.0"
 anyhow = "1"
 
 [features]

--- a/spire-api/src/agent/delegated_identity.rs
+++ b/spire-api/src/agent/delegated_identity.rs
@@ -33,10 +33,7 @@ pub const ADMIN_SOCKET_ENV: &str = "SPIRE_ADMIN_ENDPOINT_SOCKET";
 /// Gets the endpoint socket endpoint path from the environment variable `ADMIN_SOCKET_ENV`,
 /// as described in [SPIFFE standard](https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Workload_Endpoint.md#4-locating-the-endpoint).
 pub fn get_admin_socket_path() -> Option<String> {
-    match std::env::var(ADMIN_SOCKET_ENV) {
-        Ok(addr) => Some(addr),
-        Err(_) => None,
-    }
+    std::env::var(ADMIN_SOCKET_ENV).ok()
 }
 
 /// Impl for DelegatedIdentity API


### PR DESCRIPTION
Update `protox` requirements in both crates and fix `clippy` error.