### PR TITLE
fix(jwt-bundle): enforce jwt-svid JWK use filtering

### DIFF
--- a/spiffe/src/bundle/jwt/mod.rs
+++ b/spiffe/src/bundle/jwt/mod.rs
@@ -177,6 +177,18 @@ impl JwtBundle {
         let mut authorities: HashMap<String, Arc<JwtAuthority>> = HashMap::new();
 
         for key in keys {
+            // Per SPIFFE Trust Domain and Bundle spec §4.2.2:
+            // - JWKs in SPIFFE bundles MUST include `use`
+            // - For JWT-SVID verification, only keys with `use = "jwt-svid"` are valid
+            // - JWKs with missing/unknown `use` (including `use = "x509-svid"`) MUST be ignored.
+            //
+            // We enforce this by filtering here at bundle construction time, while preserving
+            // fail-closed behavior for malformed JSON/JWKs (e.g. invalid structure, missing `kid`).
+            let jwk_use = key.get("use").and_then(Value::as_str);
+            if !matches!(jwk_use, Some("jwt-svid")) {
+                continue;
+            }
+
             let jwk_json = serde_json::to_vec(key)?;
             let authority = JwtAuthority::from_jwk_json(&jwk_json)?;
             authorities.insert(authority.key_id().to_owned(), Arc::new(authority));
@@ -400,6 +412,7 @@ mod jwt_bundle_test {
             r#"{{
                 "kty": "oct",
                 "kid": "{kid}",
+                "use": "jwt-svid",
                 "k": "AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"
             }}"#
         );
@@ -421,6 +434,7 @@ mod jwt_bundle_test {
             "keys": [
                 {
                     "kty": "EC",
+                    "use": "jwt-svid",
                     "kid": "C6vs25welZOx6WksNYfbMfiw9l96pMnD",
                     "crv": "P-256",
                     "x": "ngLYQnlfF6GsojUwqtcEE3WgTNG2RUlsGhK73RNEl5k",
@@ -444,6 +458,7 @@ mod jwt_bundle_test {
             "keys": [
                 {
                     "kty": "EC",
+                    "use": "jwt-svid",
                     "kid": "C6vs25welZOx6WksNYfbMfiw9l96pMnD",
                     "crv": "P-256",
                     "x": "ngLYQnlfF6GsojUwqtcEE3WgTNG2RUlsGhK73RNEl5k",
@@ -451,6 +466,7 @@ mod jwt_bundle_test {
                 },
                 {
                     "kty": "EC",
+                    "use": "jwt-svid",
                     "kid": "gHTCunJbefYtnZnTctd84xeRWyMrEsWD",
                     "crv": "P-256",
                     "x": "7MGOl06DP9df2u8oHY6lqYFIoQWzCj9UYlp-MFeEYeY",
@@ -483,11 +499,126 @@ mod jwt_bundle_test {
     }
 
     #[test]
+    fn test_parse_bundle_filters_jwks_by_use_field() {
+        // Single JWT-SVID key is kept.
+        let jwt_svid_only = r#"{
+            "keys": [
+                {
+                    "kty": "EC",
+                    "use": "jwt-svid",
+                    "kid": "jwt-svid-kid",
+                    "crv": "P-256",
+                    "x": "ngLYQnlfF6GsojUwqtcEE3WgTNG2RUlsGhK73RNEl5k",
+                    "y": "tKbiDSUSsQ3F1P7wteeHNXIcU-cx6CgSbroeQrQHTLM"
+                }
+            ]
+        }"#;
+
+        let trust_domain = td("example.org");
+        let bundle =
+            JwtBundle::from_jwt_authorities(trust_domain.clone(), jwt_svid_only.as_bytes())
+                .expect("jwt-svid key should be accepted");
+        assert!(bundle.find_jwt_authority("jwt-svid-kid").is_some());
+
+        // Single X.509-SVID key is ignored (no authorities).
+        let x509_only = r#"{
+            "keys": [
+                {
+                    "kty": "EC",
+                    "use": "x509-svid",
+                    "kid": "x509-svid-kid",
+                    "crv": "P-256",
+                    "x": "ngLYQnlfF6GsojUwqtcEE3WgTNG2RUlsGhK73RNEl5k",
+                    "y": "tKbiDSUSsQ3F1P7wteeHNXIcU-cx6CgSbroeQrQHTLM"
+                }
+            ]
+        }"#;
+
+        let bundle =
+            JwtBundle::from_jwt_authorities(trust_domain.clone(), x509_only.as_bytes()).unwrap();
+        assert!(bundle.jwt_authorities.is_empty());
+        assert!(bundle.find_jwt_authority("x509-svid-kid").is_none());
+
+        // Single key missing `use` is ignored (no authorities).
+        let missing_use = r#"{
+            "keys": [
+                {
+                    "kty": "EC",
+                    "kid": "missing-use-kid",
+                    "crv": "P-256",
+                    "x": "ngLYQnlfF6GsojUwqtcEE3WgTNG2RUlsGhK73RNEl5k",
+                    "y": "tKbiDSUSsQ3F1P7wteeHNXIcU-cx6CgSbroeQrQHTLM"
+                }
+            ]
+        }"#;
+
+        let bundle =
+            JwtBundle::from_jwt_authorities(trust_domain.clone(), missing_use.as_bytes()).unwrap();
+        assert!(bundle.jwt_authorities.is_empty());
+        assert!(bundle.find_jwt_authority("missing-use-kid").is_none());
+
+        // Single key with unknown `use` is ignored (no authorities).
+        let unknown_use = r#"{
+            "keys": [
+                {
+                    "kty": "EC",
+                    "use": "unknown-use",
+                    "kid": "unknown-use-kid",
+                    "crv": "P-256",
+                    "x": "ngLYQnlfF6GsojUwqtcEE3WgTNG2RUlsGhK73RNEl5k",
+                    "y": "tKbiDSUSsQ3F1P7wteeHNXIcU-cx6CgSbroeQrQHTLM"
+                }
+            ]
+        }"#;
+
+        let bundle =
+            JwtBundle::from_jwt_authorities(trust_domain.clone(), unknown_use.as_bytes()).unwrap();
+        assert!(bundle.jwt_authorities.is_empty());
+        assert!(bundle.find_jwt_authority("unknown-use-kid").is_none());
+
+        // Mixed bundle: only jwt-svid key remains.
+        let mixed = r#"{
+            "keys": [
+                {
+                    "kty": "EC",
+                    "use": "x509-svid",
+                    "kid": "x509-svid-kid",
+                    "crv": "P-256",
+                    "x": "ngLYQnlfF6GsojUwqtcEE3WgTNG2RUlsGhK73RNEl5k",
+                    "y": "tKbiDSUSsQ3F1P7wteeHNXIcU-cx6CgSbroeQrQHTLM"
+                },
+                {
+                    "kty": "EC",
+                    "use": "jwt-svid",
+                    "kid": "jwt-svid-kid",
+                    "crv": "P-256",
+                    "x": "7MGOl06DP9df2u8oHY6lqYFIoQWzCj9UYlp-MFeEYeY",
+                    "y": "PSLLy5Pg0_kNGFFXq_eeq9kYcGDM3MPHJ6ncteNOr6w"
+                },
+                {
+                    "kty": "EC",
+                    "use": "unknown-use",
+                    "kid": "unknown-use-kid",
+                    "crv": "P-256",
+                    "x": "7MGOl06DP9df2u8oHY6lqYFIoQWzCj9UYlp-MFeEYeY",
+                    "y": "PSLLy5Pg0_kNGFFXq_eeq9kYcGDM3MPHJ6ncteNOr6w"
+                }
+            ]
+        }"#;
+
+        let bundle = JwtBundle::from_jwt_authorities(trust_domain, mixed.as_bytes()).unwrap();
+        assert!(bundle.find_jwt_authority("jwt-svid-kid").is_some());
+        assert!(bundle.find_jwt_authority("x509-svid-kid").is_none());
+        assert!(bundle.find_jwt_authority("unknown-use-kid").is_none());
+    }
+
+    #[test]
     fn test_parse_bundle_missing_kid_returns_missing_key_id() {
         let bundle_bytes = r#"{
             "keys": [
                 {
                     "kty": "EC",
+                    "use": "jwt-svid",
                     "crv": "P-256",
                     "x": "ngLYQnlfF6GsojUwqtcEE3WgTNG2RUlsGhK73RNEl5k",
                     "y": "tKbiDSUSsQ3F1P7wteeHNXIcU-cx6CgSbroeQrQHTLM"

--- a/spiffe/src/svid/jwt/mod.rs
+++ b/spiffe/src/svid/jwt/mod.rs
@@ -791,6 +791,67 @@ mod test {
         assert_eq!(jwt_svid.token(), token);
     }
 
+    /// When a bundle contains no usable JWT-SVID keys (e.g. only `use = "x509-svid"`),
+    /// signature validation must fail with `AuthorityNotFound` for the requested `kid`.
+    #[test]
+    fn test_parse_and_validate_fails_when_no_usable_jwt_svid_keys() {
+        let kid = "jwt-svid-kid";
+
+        // Signing key used to mint the token (ES256).
+        let signing_key = SigningKey::random(&mut OsRng);
+        let pkcs8_der = signing_key
+            .to_pkcs8_der()
+            .expect("PKCS#8 DER serialization should succeed");
+        let encoding_key = EncodingKey::from_ec_der(pkcs8_der.as_bytes());
+
+        // Build a bundle from SPIFFE bundle JSON where the only JWK has `use = "x509-svid"`.
+        // Per spec, this key must be ignored for JWT-SVID verification, leaving the bundle
+        // effectively empty for JWT authorities.
+        let verifying_key = signing_key.verifying_key();
+        let point = verifying_key.to_encoded_point(false);
+        let x = point.x().expect("x coordinate missing");
+        let y = point.y().expect("y coordinate missing");
+
+        let jwks = serde_json::json!({
+            "keys": [{
+                "kty": "EC",
+                "crv": "P-256",
+                "x": b64u(x),
+                "y": b64u(y),
+                "alg": "ES256",
+                "use": "x509-svid",
+                "kid": kid,
+            }]
+        });
+
+        let trust_domain = TrustDomain::new("example.org").expect("valid trust domain");
+        let jwks_bytes = serde_json::to_vec(&jwks).expect("jwks should serialize");
+        let bundle =
+            JwtBundle::from_jwt_authorities(trust_domain, &jwks_bytes).expect("jwks parses");
+
+        // BundleSet containing a bundle with no usable JWT-SVID authorities.
+        let mut bundle_set = JwtBundleSet::new();
+        bundle_set.add_bundle(bundle);
+
+        // Generate a token that references the same `kid`. Validation must fail because
+        // the bundle has no JWT-SVID authorities after filtering by `use`.
+        let target_audience = vec!["audience".to_owned()];
+        let token = generate_token(
+            target_audience,
+            "spiffe://example.org/service".to_string(),
+            Some("JWT".to_string()),
+            Some(kid.to_string()),
+            0xFFFF_FFFF,
+            Algorithm::ES256,
+            &encoding_key,
+        );
+
+        let result = JwtSvid::parse_and_validate(&token, &bundle_set, &["audience"]).unwrap_err();
+        assert!(
+            matches!(result, JwtSvidError::AuthorityNotFound(missing_kid) if missing_kid == kid)
+        );
+    }
+
     #[test]
     fn test_parse_jwt_svid_with_unsupported_algorithm() {
         let target_audience = vec!["audience".to_owned()];


### PR DESCRIPTION
## Context
SPIFFE JWT bundle parsing currently accepts any JWK with a `kid`, regardless of the JWK `use` field. Per the SPIFFE Trust Domain and Bundle spec and local docs:
- JWKs in SPIFFE bundles MUST include `use`
- For JWT-SVID verification, only `use = "jwt-svid"` keys are valid authorities
- Keys with missing/unknown `use` (including `x509-svid`) MUST be ignored

This PR aligns the JWT bundle parsing behavior with the spec and tightens verification semantics.

## Changes
- Enforce `use == "jwt-svid"` filtering in `JwtBundle::from_jwt_authorities` when constructing JWT authorities from JWKS, ignoring JWKs with:
  - missing `use`
  - `use = "x509-svid"`
  - any other/unknown `use` value
- Preserve fail-closed behavior for malformed JSON / malformed JWKs (e.g., invalid structure or missing `kid`) in `JwtAuthority::from_jwk_json`.
- Update existing JWT bundle tests to include `use = "jwt-svid"` where appropriate for JWT-SVID keys.
- Add focused tests to cover:
  - bundle with one JWK with `use="jwt-svid"` → authority included
  - bundle with one JWK with `use="x509-svid"` → authority ignored
  - bundle with one JWK missing `use` → authority ignored
  - bundle with one JWK with unknown `use` → authority ignored
  - mixed bundle (jwt-svid + x509-svid + unknown) → only `jwt-svid` authority retained
- Add an end-to-end JWT-SVID validation test to assert that when a bundle contains no usable JWT-SVID keys (only `use="x509-svid"`), `JwtSvid::parse_and_validate` fails with `AuthorityNotFound` for the requested `kid`.
- Wire workspace `[patch.crates-io]` and `spiffe-rustls-tokio` dev-dependencies so examples/tests consistently use the local `spiffe`/`spiffe-rustls` crates.

## Security
- Advisory: none
- Fix: ensures JWT-SVID verification only trusts JWKs explicitly marked `use = "jwt-svid"` and treats bundles with no usable keys as having no authorities, causing signature validation to fail rather than accidentally accepting tokens.

## Compatibility
- Breaking changes:
  - Behavioral tightening for JWT bundles parsed from SPIFFE-compliant JWKS:
    - JWKs without `use` or with non-`"jwt-svid"` `use` are now ignored for JWT-SVID verification.
    - Deployments that previously relied on non-spec-compliant JWKs (e.g. missing `use` or `use="sig"`) in SPIFFE bundles will see those keys no longer used for JWT-SVID verification and may observe `AuthorityNotFound` errors until bundles are corrected.
  - No public API surface or type changes.
- Affected crates/features:
  - `spiffe` crate, `jwt` / `jwt-source` / `jwt-verify-*` paths that depend on `JwtBundle` and `JwtSvid::parse_and_validate`.

## Testing
- `cargo test -p spiffe` 
- `make test`
- New tests specifically cover:
  - JWK `use` filtering behavior in `JwtBundle::from_jwt_authorities`
  - No-usable-JWT-SVID-keys path resulting in `AuthorityNotFound`

## Release notes
- Enforce JWK `use = "jwt-svid"` filtering for JWT bundles and ignore JWKs with missing/unknown `use` (including `x509-svid`), so JWT-SVID verification only trusts spec-compliant JWT authorities and fails with `AuthorityNotFound` when no usable keys are present.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxlambrecht/rust-spiffe/318)
<!-- Reviewable:end -->
