### PR TITLE
fix: only cancel `X509Source` when the last instance is dropped

### DIFF
--- a/spiffe/src/x509_source/source.rs
+++ b/spiffe/src/x509_source/source.rs
@@ -171,6 +171,13 @@ impl Inner {
     }
 }
 
+impl Drop for Inner {
+    fn drop(&mut self) {
+        // Best-effort cancellation. Do not block in Drop.
+        self.cancel.cancel();
+    }
+}
+
 impl Debug for Inner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("X509Source")
@@ -643,13 +650,6 @@ impl Inner {
             self.limits,
             self.metrics.as_deref(),
         )
-    }
-}
-
-impl Drop for X509Source {
-    fn drop(&mut self) {
-        // Best-effort cancellation. Do not block in Drop.
-        self.inner.cancel.cancel();
     }
 }
 


### PR DESCRIPTION
If the `X509Source` was cloned and `Inner` was held by multiple owners, then if any owner dropped the source it would immediately close it even though other owners were still using it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxlambrecht/rust-spiffe/327)
<!-- Reviewable:end -->
