### PR TITLE
chore(release): spiffe 0.13.0, spiffe-rustls 0.4.9, spiffe-rustls-tokio 0.1.4, spire-api 0.5.5

### DIFF
--- a/spiffe-rustls-grpc-examples/Cargo.toml
+++ b/spiffe-rustls-grpc-examples/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-spiffe = { version = "0.12", features = ["x509-source"]}
+spiffe = { version = "0.13", path = "../spiffe", features = ["x509-source"] }
 spiffe-rustls = { path = "../spiffe-rustls", features = ["ring"] }
 
 # gRPC stack

--- a/spiffe-rustls-tokio/CHANGELOG.md
+++ b/spiffe-rustls-tokio/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.4] – 2026-04-18
+
+### Changed
+
+- Bump `spiffe` dependency from 0.12 to 0.13.
+
+
 ## [0.1.3] – 2026-02-25
 
 ### Changed

--- a/spiffe-rustls-tokio/Cargo.toml
+++ b/spiffe-rustls-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spiffe-rustls-tokio"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -19,7 +19,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dependencies]
-spiffe = { version = "0.12", features = ["x509-source"] }
+spiffe = { version = "0.13", path = "../spiffe", features = ["x509-source"] }
 tokio = { version = "1", default-features = false, features = ["net", "rt"] }
 tokio-rustls = { version = "0.26", default-features = false }
 rustls = { version = "0.23", default-features = false, features = ["std"] }
@@ -28,7 +28,7 @@ thiserror = "2"
 [dev-dependencies]
 anyhow = "1"
 env_logger = "0.11"
-spiffe-rustls = { version = "0.4" }
+spiffe-rustls = { version = "0.4.9", path = "../spiffe-rustls" }
 tokio = { version = "1", default-features = false, features = [
     "rt-multi-thread",
     "signal",

--- a/spiffe-rustls-tokio/README.md
+++ b/spiffe-rustls-tokio/README.md
@@ -21,7 +21,7 @@ Add `spiffe-rustls-tokio` to your `Cargo.toml`:
 [dependencies]
 spiffe-rustls-tokio = "0.1"
 spiffe-rustls = "0.4"
-spiffe = { version = "0.11", features = ["x509-source"] }
+spiffe = { version = "0.13", features = ["x509-source"] }
 ```
 
 ---

--- a/spiffe-rustls/CHANGELOG.md
+++ b/spiffe-rustls/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog
 
-## [Unreleased]
+## [0.4.9] – 2026-04-18
+
+### Changed
+
+- Bump the `spiffe` dependency from 0.12 to 0.13.
 
 ### Fixed
 
-- Client TLS: Do not treat webpki hostname or SNI mismatches as fatal during X.509-SVID server verification. SPIFFE TLS relies on validation against the trust bundle plus SPIFFE ID authorization through the `Authorizer`, not on DNS or IP SAN matching.
+- Skip TLS hostname mismatch checks during SPIFFE server X.509-SVID verification (#329). WebPKI hostname and SNI mismatches are no longer treated as fatal during server certificate verification. SPIFFE TLS relies on trust bundle validation and SPIFFE ID authorization through the `Authorizer`, not on DNS or IP SAN matching.
+
 
 ## [0.4.8] – 2026-02-24
 

--- a/spiffe-rustls/Cargo.toml
+++ b/spiffe-rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spiffe-rustls"
-version = "0.4.8"
+version = "0.4.9"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -19,7 +19,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dependencies]
-spiffe = { version = "0.12", features = ["x509-source"] }
+spiffe = { version = "0.13", path = "../spiffe", features = ["x509-source"] }
 rustls = { version = "0.23", default-features = false, features = ["std"] }
 tokio = { version = "1", default-features = false, features = ["rt", "sync"] }
 tokio-util = "0.7"

--- a/spiffe/CHANGELOG.md
+++ b/spiffe/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.13.0] – 2026-04-18
+
+### Breaking changes
+
+- **JWT:** Added ES512 parsing support; offline verification errors are backend-specific (#322).
+
+### Fixed
+
+- **X509 source:** Only cancel the underlying source when the last `X509Source` is dropped (#327).
+- **X.509-SVID:** Reject leaf certificates with multiple URI SAN entries (#325).
+- **X.509-SVID:** Reject root-only leaf SPIFFE IDs.
+- **SPIFFE ID:** Enforce trust domain length limits and adjust parse-time URI limits.
+- **SPIFFE ID:** Accept the `spiffe:` scheme case-insensitively and canonicalize the trust domain (#320).
+
+
 ## [0.12.0] – 2026-02-24
 
 ### Breaking changes

--- a/spiffe/Cargo.toml
+++ b/spiffe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spiffe"
-version = "0.12.0"
+version = "0.13.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/spiffe/README.md
+++ b/spiffe/README.md
@@ -20,16 +20,16 @@ Add `spiffe` to your `Cargo.toml`. All features are opt-in:
 ```toml
 [dependencies]
 # Minimal: only SPIFFE primitives 
-spiffe = "0.12"
+spiffe = "0.13"
 
 # OR X.509 workloads (recommended)
-# spiffe = { version = "0.12", features = ["x509-source"] }
+# spiffe = { version = "0.13", features = ["x509-source"] }
 
 # OR JWT workloads (recommended)
-# spiffe = { version = "0.12", features = ["jwt-source"] }
+# spiffe = { version = "0.13", features = ["jwt-source"] }
 
 # OR Direct Workload API usage
-# spiffe = { version = "0.12", features = ["workload-api"] }
+# spiffe = { version = "0.13", features = ["workload-api"] }
 ```
 
 ---
@@ -275,14 +275,14 @@ backend.
 
 ```toml
 [dependencies]
-spiffe = { version = "0.12", features = ["jwt-verify-rust-crypto"] }
+spiffe = { version = "0.13", features = ["jwt-verify-rust-crypto"] }
 ```
 
 #### Using the AWS-LC backend
 
 ```toml
 [dependencies]
-spiffe = { version = "0.12", features = ["jwt-verify-aws-lc-rs"] }
+spiffe = { version = "0.13", features = ["jwt-verify-aws-lc-rs"] }
 ```
 
 This enables local signature verification using JWT authorities from bundles:
@@ -436,7 +436,7 @@ facade. Events are emitted via `log::debug!`, `log::info!`, `log::warn!`, and `l
 
 ```toml
 [dependencies]
-spiffe = { version = "0.12", features = ["logging"] }
+spiffe = { version = "0.13", features = ["logging"] }
 ```
 
 **Note:** The `logging` feature is not included in the default `workload-api` feature.
@@ -452,7 +452,7 @@ or distributed tracing systems. When both `tracing` and `logging` features are e
 
 ```toml
 [dependencies]
-spiffe = { version = "0.12", features = ["tracing"] }
+spiffe = { version = "0.13", features = ["tracing"] }
 ```
 
 **Note:** The `tracing` and `logging` features are not mutually exclusive. When both
@@ -468,7 +468,7 @@ In addition to the higher-level bundles (`workload-api-x509`, `workload-api-jwt`
 
 ```toml
 [dependencies]
-spiffe = { version = "0.12", features = ["workload-api-core"] }
+spiffe = { version = "0.13", features = ["workload-api-core"] }
 ```
 
 This feature includes:

--- a/spire-api/CHANGELOG.md
+++ b/spire-api/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.5.5] – 2026-04-18
+
+### Changed
+
+- Bump `spiffe` dependency from 0.12 to 0.13.
+
 ## [0.5.4] – 2026-02-25
 
 ### Changed

--- a/spire-api/Cargo.toml
+++ b/spire-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spire-api"
-version = "0.5.4"
+version = "0.5.5"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ workspace = true
 [dependencies]
 futures = { version = "0.3", default-features = false }
 prost = { version = "0.14", default-features = false }
-spiffe = { version = "0.12", features = ["x509", "jwt", "transport-grpc"] }
+spiffe = { version = "0.13", path = "../spiffe", features = ["x509", "jwt", "transport-grpc"] }
 thiserror = { version = "2", default-features = false }
 tonic = { version = "0.14", default-features = false, features = ["transport", "codegen"] }
 tonic-prost = { version = "0.14", default-features = false }


### PR DESCRIPTION
## Context

Prepare coordinated releases for workspace crates that depend on `spiffe`. This PR bumps crate versions and updates the corresponding changelogs and README entries where needed.

## Changes

- `spiffe` `0.13.0`: update version, `CHANGELOG.md`, and README dependency examples.
- `spiffe-rustls` `0.4.9`: update version, `CHANGELOG.md` (including the TLS hostname / X.509-SVID server verification fix in #329), and bump `spiffe` to `0.13` via `path` + `version`.
- `spiffe-rustls-tokio` `0.1.4`: update version, `CHANGELOG.md`, and README; bump `spiffe` to `0.13` via `path` + `version`; add a dev-dependency on `spiffe-rustls` via `path` + `version` so examples do not mix registry and workspace `spiffe`.
- `spire-api` `0.5.5`: update version, `CHANGELOG.md`, and bump `spiffe` to `0.13` via `path` + `version`.
- `spiffe-rustls-grpc-examples`: bump `spiffe` to `0.13` via `path` + `version` only. This crate remains `publish = false`.

Workspace crates use `path` + `version` for `spiffe` so local and CI builds do not depend on `spiffe` `0.13` already being available on crates.io before merge. `cargo publish` still records a normal version requirement for registry users.

## Security

Review should focus on the identity and TLS verification paths affected by the `spiffe-rustls` server verification change (#329), as well as the JWT and X.509 changes documented in `spiffe/CHANGELOG.md`. 

## Compatibility

- **MSRV:** unchanged (`1.88` for the workspace).
- **Breaking changes:** `spiffe` `0.13.0` introduces breaking changes. See `spiffe/CHANGELOG.md` for details.
- **Downstream impact:** downstream users should upgrade `spiffe` and, where applicable, `spire-api`, `spiffe-rustls`, and `spiffe-rustls-tokio` together as part of this release set.
- **`spire-api` public API:** unchanged. This is a dependency bump only.

## Testing

Covered by CI with `cargo check --workspace --all-targets` and the existing test suite.

## Release process

After merge, create and push tags in dependency order for publishing, for example: `spiffe-0.13.0`, then `spire-api-0.5.5`, `spiffe-rustls-0.4.9`, and `spiffe-rustls-tokio-0.1.4`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxlambrecht/rust-spiffe/331)
<!-- Reviewable:end -->
