### PR TITLE
fix(spiffe): close source supervisors on last handle drop

### DIFF
--- a/spiffe/src/jwt_source/source.rs
+++ b/spiffe/src/jwt_source/source.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{watch, Mutex};
 use tokio::task::JoinHandle;
-use tokio_util::sync::CancellationToken;
+use tokio_util::sync::{CancellationToken, DropGuard};
 
 #[cfg(test)]
 use crate::WorkloadApiError;
@@ -51,6 +51,7 @@ use crate::WorkloadApiError;
 #[derive(Clone, Debug)]
 pub struct JwtSourceUpdates {
     rx: watch::Receiver<u64>,
+    shutdown: CancellationToken,
 }
 
 impl JwtSourceUpdates {
@@ -71,11 +72,26 @@ impl JwtSourceUpdates {
     /// - Explicit shutdown via [`JwtSource::shutdown`] or [`JwtSource::shutdown_with_timeout`]
     /// - Internal task termination (e.g., supervisor task panic)
     pub async fn changed(&mut self) -> Result<u64, JwtSourceError> {
-        self.rx
-            .changed()
-            .await
-            .map_err(|watch::error::RecvError { .. }| JwtSourceError::Closed)?;
-        Ok(*self.rx.borrow())
+        if self.rx.has_changed().unwrap_or(false) {
+            self.rx
+                .changed()
+                .await
+                .map_err(|watch::error::RecvError { .. }| JwtSourceError::Closed)?;
+            return Ok(*self.rx.borrow());
+        }
+
+        if self.shutdown.is_cancelled() {
+            return Err(JwtSourceError::Closed);
+        }
+
+        tokio::select! {
+            biased;
+            result = self.rx.changed() => {
+                result.map_err(|watch::error::RecvError { .. }| JwtSourceError::Closed)?;
+                Ok(*self.rx.borrow())
+            }
+            () = self.shutdown.cancelled() => Err(JwtSourceError::Closed),
+        }
     }
 
     /// Returns the last sequence number without waiting.
@@ -132,6 +148,7 @@ impl JwtSourceUpdates {
 #[derive(Clone, Debug)]
 pub struct JwtSource {
     inner: Arc<Inner>,
+    _shutdown_guard: Arc<DropGuard>,
 }
 
 pub(super) struct Inner {
@@ -158,7 +175,7 @@ pub(super) struct Inner {
     // Update notifications (monotonic sequence).
     update_seq: AtomicU64,
     update_tx: watch::Sender<u64>,
-    update_rx: watch::Receiver<u64>,
+    _update_rx: watch::Receiver<u64>,
 
     // Supervisor task handle (joined/aborted at shutdown).
     supervisor: Mutex<Option<JoinHandle<()>>>,
@@ -243,7 +260,7 @@ impl Debug for Inner {
             .field("cancel", &self.cancel)
             .field("update_seq", &self.update_seq)
             .field("update_tx", &"<watch::Sender<u64>>")
-            .field("update_rx", &"<watch::Receiver<u64>>")
+            .field("_update_rx", &"<watch::Receiver<u64>>")
             .field("supervisor", &"<Mutex<Option<JoinHandle<()>>>>")
             .finish()
     }
@@ -315,7 +332,8 @@ impl JwtSource {
     /// ```
     pub fn updated(&self) -> JwtSourceUpdates {
         JwtSourceUpdates {
-            rx: self.inner.update_rx.clone(),
+            rx: self.inner.update_tx.subscribe(),
+            shutdown: self.inner.cancel.clone(),
         }
     }
 
@@ -597,6 +615,7 @@ impl JwtSource {
 
         let (update_tx, update_rx) = watch::channel(0u64);
         let cancel = CancellationToken::new();
+        let shutdown_guard = Arc::new(cancel.clone().drop_guard());
 
         let initial_bundle_set =
             initial_sync_with_retry(&make_client, &cancel, reconnect, limits, metrics.as_deref())
@@ -628,19 +647,23 @@ impl JwtSource {
             cancel,
             update_seq: AtomicU64::new(0),
             update_tx,
-            update_rx,
+            _update_rx: update_rx,
             supervisor: Mutex::new(None),
         });
 
         let task_inner = Arc::clone(&inner);
         let token = task_inner.cancel.clone();
         let handle = tokio::spawn(async move {
+            let _cancel_on_drop = token.clone().drop_guard();
             task_inner.run_update_supervisor(token).await;
         });
 
         *inner.supervisor.lock().await = Some(handle);
 
-        Ok(Self { inner })
+        Ok(Self {
+            inner,
+            _shutdown_guard: shutdown_guard,
+        })
     }
 
     /// Test-only constructor that creates a `JwtSource` with a provided initial bundle set
@@ -659,6 +682,7 @@ impl JwtSource {
 
         let (update_tx, update_rx) = watch::channel(0u64);
         let cancel = CancellationToken::new();
+        let shutdown_guard = Arc::new(cancel.clone().drop_guard());
 
         let make_client: ClientFactory =
             Arc::new(|| Box::pin(async move { Err(WorkloadApiError::EmptyResponse) }));
@@ -676,12 +700,13 @@ impl JwtSource {
             cancel,
             update_seq: AtomicU64::new(0),
             update_tx,
-            update_rx,
+            _update_rx: update_rx,
             supervisor: Mutex::new(None),
         };
 
         Self {
             inner: Arc::new(inner),
+            _shutdown_guard: shutdown_guard,
         }
     }
 
@@ -741,13 +766,6 @@ impl Inner {
     }
 }
 
-impl Drop for JwtSource {
-    fn drop(&mut self) {
-        // Best-effort cancellation. Do not block in Drop.
-        self.inner.cancel.cancel();
-    }
-}
-
 impl BundleSource for JwtSource {
     type Item = JwtBundle;
     type Error = JwtSourceError;
@@ -768,6 +786,13 @@ mod tests {
     use crate::bundle::jwt::JwtAuthority;
     use std::collections::HashMap;
     use std::sync::Mutex;
+
+    fn updates_for_test(rx: watch::Receiver<u64>) -> JwtSourceUpdates {
+        JwtSourceUpdates {
+            rx,
+            shutdown: CancellationToken::new(),
+        }
+    }
 
     fn jwk_with_kid(kid: &str) -> JwtAuthority {
         let json = format!(
@@ -792,7 +817,7 @@ mod tests {
     #[tokio::test]
     async fn test_wait_for_immediate_satisfaction() {
         let (tx, rx) = watch::channel(5u64);
-        let mut updates = JwtSourceUpdates { rx };
+        let mut updates = updates_for_test(rx);
 
         // Predicate is already satisfied (current value is 5, which is > 3)
         let result = updates.wait_for(|&seq| seq > 3).await;
@@ -811,7 +836,7 @@ mod tests {
     #[tokio::test]
     async fn test_wait_for_waits_when_not_satisfied() {
         let (tx, rx) = watch::channel(1u64);
-        let mut updates = JwtSourceUpdates { rx };
+        let mut updates = updates_for_test(rx);
 
         // Spawn a task to update the value after a short delay
         let tx_clone = tx.clone();
@@ -834,7 +859,7 @@ mod tests {
         // Verify that updated().changed() only notifies on rotations after initial sync,
         // not on the initial sync itself. The initial sequence number is 0.
         let (tx, rx) = watch::channel(0u64);
-        let mut updates = JwtSourceUpdates { rx: rx.clone() };
+        let mut updates = updates_for_test(rx.clone());
 
         // Initial value is 0, so changed() should wait for an update
         let tx_clone = tx.clone();
@@ -857,8 +882,136 @@ mod tests {
     async fn test_updated_initial_sequence_is_zero() {
         // Verify that the initial sequence number is 0
         let (_tx, rx) = watch::channel(0u64);
-        let updates = JwtSourceUpdates { rx };
+        let updates = updates_for_test(rx);
         assert_eq!(updates.last(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_updated_subscribes_at_current_sequence() {
+        let source = JwtSource::new_for_test(
+            create_test_bundle_set(),
+            ReconnectConfig::default(),
+            ResourceLimits::default(),
+            None,
+        );
+
+        source.inner.notify_update();
+
+        let mut updates = source.updated();
+        assert_eq!(updates.last(), 1);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), updates.changed())
+                .await
+                .is_err(),
+            "new subscribers should wait for updates after subscription"
+        );
+
+        source.inner.notify_update();
+        assert_eq!(updates.changed().await.unwrap(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_updates_changed_returns_closed_after_shutdown() {
+        let source = JwtSource::new_for_test(
+            create_test_bundle_set(),
+            ReconnectConfig::default(),
+            ResourceLimits::default(),
+            None,
+        );
+        let mut updates = source.updated();
+
+        source.shutdown().await;
+
+        let result = tokio::time::timeout(Duration::from_secs(1), updates.changed())
+            .await
+            .expect("changed should return after shutdown");
+        assert!(matches!(result, Err(JwtSourceError::Closed)));
+    }
+
+    #[tokio::test]
+    async fn test_updates_wait_for_returns_closed_after_shutdown() {
+        let source = JwtSource::new_for_test(
+            create_test_bundle_set(),
+            ReconnectConfig::default(),
+            ResourceLimits::default(),
+            None,
+        );
+        let mut updates = source.updated();
+
+        source.shutdown().await;
+
+        let result = tokio::time::timeout(Duration::from_secs(1), updates.wait_for(|&seq| seq > 0))
+            .await
+            .expect("wait_for should return after shutdown");
+        assert!(matches!(result, Err(JwtSourceError::Closed)));
+    }
+
+    #[tokio::test]
+    async fn test_updates_changed_delivers_pending_update_before_closed() {
+        let source = JwtSource::new_for_test(
+            create_test_bundle_set(),
+            ReconnectConfig::default(),
+            ResourceLimits::default(),
+            None,
+        );
+        let mut updates = source.updated();
+
+        source.inner.notify_update();
+        source.inner.cancel.cancel();
+
+        assert_eq!(updates.changed().await.unwrap(), 1);
+        let result = tokio::time::timeout(Duration::from_secs(1), updates.changed())
+            .await
+            .expect("changed should return closed after pending update is observed");
+        assert!(matches!(result, Err(JwtSourceError::Closed)));
+    }
+
+    #[tokio::test]
+    async fn test_updates_changed_returns_closed_after_last_source_drop() {
+        let source = JwtSource::new_for_test(
+            create_test_bundle_set(),
+            ReconnectConfig::default(),
+            ResourceLimits::default(),
+            None,
+        );
+        let mut updates = source.updated();
+
+        drop(source);
+
+        let result = tokio::time::timeout(Duration::from_secs(1), updates.changed())
+            .await
+            .expect("changed should return after last source handle is dropped");
+        assert!(matches!(result, Err(JwtSourceError::Closed)));
+    }
+
+    #[tokio::test]
+    async fn test_dropping_last_source_handle_cancels_supervisor_token() {
+        let source = JwtSource::new_for_test(
+            create_test_bundle_set(),
+            ReconnectConfig::default(),
+            ResourceLimits::default(),
+            None,
+        );
+        let clone = source.clone();
+        let task_inner = Arc::clone(&source.inner);
+        let token = task_inner.cancel.clone();
+        let (stopped_tx, stopped_rx) = tokio::sync::oneshot::channel();
+
+        tokio::spawn(async move {
+            token.cancelled().await;
+            let _unused: Result<_, _> = stopped_tx.send(());
+            drop(task_inner);
+        });
+
+        drop(source);
+        // One public handle still holds the shutdown guard, so cancellation must not fire yet.
+        assert!(!clone.inner.cancel.is_cancelled());
+
+        drop(clone);
+        tokio::time::timeout(Duration::from_secs(1), stopped_rx)
+            .await
+            .expect("supervisor token should be cancelled when last source handle is dropped")
+            .expect("supervisor observer should send stop notification");
     }
 
     /// Test metrics recorder that counts error recordings by kind.

--- a/spiffe/src/x509_source/source.rs
+++ b/spiffe/src/x509_source/source.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{watch, Mutex};
 use tokio::task::JoinHandle;
-use tokio_util::sync::CancellationToken;
+use tokio_util::sync::{CancellationToken, DropGuard};
 
 #[cfg(test)]
 use crate::WorkloadApiError;
@@ -52,6 +52,7 @@ use crate::WorkloadApiError;
 #[derive(Clone, Debug)]
 pub struct X509SourceUpdates {
     rx: watch::Receiver<u64>,
+    shutdown: CancellationToken,
 }
 
 impl X509SourceUpdates {
@@ -72,11 +73,26 @@ impl X509SourceUpdates {
     /// - Explicit shutdown via [`X509Source::shutdown`] or [`X509Source::shutdown_with_timeout`]
     /// - Internal task termination (e.g., supervisor task panic)
     pub async fn changed(&mut self) -> Result<u64, X509SourceError> {
-        self.rx
-            .changed()
-            .await
-            .map_err(|watch::error::RecvError { .. }| X509SourceError::Closed)?;
-        Ok(*self.rx.borrow())
+        if self.rx.has_changed().unwrap_or(false) {
+            self.rx
+                .changed()
+                .await
+                .map_err(|watch::error::RecvError { .. }| X509SourceError::Closed)?;
+            return Ok(*self.rx.borrow());
+        }
+
+        if self.shutdown.is_cancelled() {
+            return Err(X509SourceError::Closed);
+        }
+
+        tokio::select! {
+            biased;
+            result = self.rx.changed() => {
+                result.map_err(|watch::error::RecvError { .. }| X509SourceError::Closed)?;
+                Ok(*self.rx.borrow())
+            }
+            () = self.shutdown.cancelled() => Err(X509SourceError::Closed),
+        }
     }
 
     /// Returns the last sequence number without waiting.
@@ -130,6 +146,7 @@ impl X509SourceUpdates {
 #[derive(Clone, Debug)]
 pub struct X509Source {
     inner: Arc<Inner>,
+    _shutdown_guard: Arc<DropGuard>,
 }
 
 pub(super) struct Inner {
@@ -153,7 +170,7 @@ pub(super) struct Inner {
     // Update notifications (monotonic sequence).
     update_seq: AtomicU64,
     update_tx: watch::Sender<u64>,
-    update_rx: watch::Receiver<u64>,
+    _update_rx: watch::Receiver<u64>,
 
     // Supervisor task handle (joined/aborted at shutdown).
     supervisor: Mutex<Option<JoinHandle<()>>>,
@@ -168,13 +185,6 @@ impl Inner {
     }
     pub(super) fn make_client(&self) -> &ClientFactory {
         &self.make_client
-    }
-}
-
-impl Drop for Inner {
-    fn drop(&mut self) {
-        // Best-effort cancellation. Do not block in Drop.
-        self.cancel.cancel();
     }
 }
 
@@ -198,7 +208,7 @@ impl Debug for Inner {
             .field("cancel", &self.cancel)
             .field("update_seq", &self.update_seq)
             .field("update_tx", &"<watch::Sender<u64>>")
-            .field("update_rx", &"<watch::Receiver<u64>>")
+            .field("_update_rx", &"<watch::Receiver<u64>>")
             .field("supervisor", &"<Mutex<Option<JoinHandle<()>>>>")
             .finish()
     }
@@ -272,7 +282,8 @@ impl X509Source {
     /// ```
     pub fn updated(&self) -> X509SourceUpdates {
         X509SourceUpdates {
-            rx: self.inner.update_rx.clone(),
+            rx: self.inner.update_tx.subscribe(),
+            shutdown: self.inner.cancel.clone(),
         }
     }
 
@@ -518,6 +529,7 @@ impl X509Source {
 
         let (update_tx, update_rx) = watch::channel(0u64);
         let cancel = CancellationToken::new();
+        let shutdown_guard = Arc::new(cancel.clone().drop_guard());
 
         let initial_ctx = initial_sync_with_retry(
             &make_client,
@@ -541,19 +553,23 @@ impl X509Source {
             cancel,
             update_seq: AtomicU64::new(0),
             update_tx,
-            update_rx,
+            _update_rx: update_rx,
             supervisor: Mutex::new(None),
         });
 
         let task_inner = Arc::clone(&inner);
         let token = task_inner.cancel.clone();
         let handle = tokio::spawn(async move {
+            let _cancel_on_drop = token.clone().drop_guard();
             task_inner.run_update_supervisor(token).await;
         });
 
         *inner.supervisor.lock().await = Some(handle);
 
-        Ok(Self { inner })
+        Ok(Self {
+            inner,
+            _shutdown_guard: shutdown_guard,
+        })
     }
 
     /// Test-only constructor that creates an `X509Source` with a provided initial context
@@ -573,6 +589,7 @@ impl X509Source {
 
         let (update_tx, update_rx) = watch::channel(0u64);
         let cancel = CancellationToken::new();
+        let shutdown_guard = Arc::new(cancel.clone().drop_guard());
 
         let make_client: ClientFactory =
             Arc::new(|| Box::pin(async move { Err(WorkloadApiError::EmptyResponse) }));
@@ -589,12 +606,13 @@ impl X509Source {
             cancel,
             update_seq: AtomicU64::new(0),
             update_tx,
-            update_rx,
+            _update_rx: update_rx,
             supervisor: Mutex::new(None),
         };
 
         Self {
             inner: Arc::new(inner),
+            _shutdown_guard: shutdown_guard,
         }
     }
 
@@ -682,10 +700,24 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::Mutex;
 
+    fn updates_for_test(rx: watch::Receiver<u64>) -> X509SourceUpdates {
+        X509SourceUpdates {
+            rx,
+            shutdown: CancellationToken::new(),
+        }
+    }
+
+    fn test_x509_context() -> Arc<X509Context> {
+        let cert_bytes = include_bytes!("../../tests/testdata/svid/x509/1-svid-chain.der");
+        let key_bytes = include_bytes!("../../tests/testdata/svid/x509/1-key.der");
+        let svid = Arc::new(X509Svid::parse_from_der(cert_bytes, key_bytes).unwrap());
+        Arc::new(X509Context::new([svid], Arc::new(X509BundleSet::new())))
+    }
+
     #[tokio::test]
     async fn test_wait_for_immediate_satisfaction() {
         let (tx, rx) = watch::channel(5u64);
-        let mut updates = X509SourceUpdates { rx };
+        let mut updates = updates_for_test(rx);
 
         // Predicate is already satisfied (current value is 5, which is > 3)
         let result = updates.wait_for(|&seq| seq > 3).await;
@@ -704,7 +736,7 @@ mod tests {
     #[tokio::test]
     async fn test_wait_for_waits_when_not_satisfied() {
         let (tx, rx) = watch::channel(1u64);
-        let mut updates = X509SourceUpdates { rx };
+        let mut updates = updates_for_test(rx);
 
         // Spawn a task to update the value after a short delay
         let tx_clone = tx.clone();
@@ -727,7 +759,7 @@ mod tests {
         // Verify that updated().changed() only notifies on rotations after initial sync,
         // not on the initial sync itself. The initial sequence number is 0.
         let (tx, rx) = watch::channel(0u64);
-        let mut updates = X509SourceUpdates { rx: rx.clone() };
+        let mut updates = updates_for_test(rx.clone());
 
         // Initial value is 0, so changed() should wait for an update
         let tx_clone = tx.clone();
@@ -750,8 +782,142 @@ mod tests {
     async fn test_updated_initial_sequence_is_zero() {
         // Verify that the initial sequence number is 0
         let (_tx, rx) = watch::channel(0u64);
-        let updates = X509SourceUpdates { rx };
+        let updates = updates_for_test(rx);
         assert_eq!(updates.last(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_updated_subscribes_at_current_sequence() {
+        let source = X509Source::new_for_test(
+            test_x509_context(),
+            ReconnectConfig::default(),
+            ResourceLimits::default(),
+            None,
+            None,
+        );
+
+        source.inner.notify_update();
+
+        let mut updates = source.updated();
+        assert_eq!(updates.last(), 1);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), updates.changed())
+                .await
+                .is_err(),
+            "new subscribers should wait for updates after subscription"
+        );
+
+        source.inner.notify_update();
+        assert_eq!(updates.changed().await.unwrap(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_updates_changed_returns_closed_after_shutdown() {
+        let source = X509Source::new_for_test(
+            test_x509_context(),
+            ReconnectConfig::default(),
+            ResourceLimits::default(),
+            None,
+            None,
+        );
+        let mut updates = source.updated();
+
+        source.shutdown().await;
+
+        let result = tokio::time::timeout(Duration::from_secs(1), updates.changed())
+            .await
+            .expect("changed should return after shutdown");
+        assert!(matches!(result, Err(X509SourceError::Closed)));
+    }
+
+    #[tokio::test]
+    async fn test_updates_wait_for_returns_closed_after_shutdown() {
+        let source = X509Source::new_for_test(
+            test_x509_context(),
+            ReconnectConfig::default(),
+            ResourceLimits::default(),
+            None,
+            None,
+        );
+        let mut updates = source.updated();
+
+        source.shutdown().await;
+
+        let result = tokio::time::timeout(Duration::from_secs(1), updates.wait_for(|&seq| seq > 0))
+            .await
+            .expect("wait_for should return after shutdown");
+        assert!(matches!(result, Err(X509SourceError::Closed)));
+    }
+
+    #[tokio::test]
+    async fn test_updates_changed_delivers_pending_update_before_closed() {
+        let source = X509Source::new_for_test(
+            test_x509_context(),
+            ReconnectConfig::default(),
+            ResourceLimits::default(),
+            None,
+            None,
+        );
+        let mut updates = source.updated();
+
+        source.inner.notify_update();
+        source.inner.cancel.cancel();
+
+        assert_eq!(updates.changed().await.unwrap(), 1);
+        let result = tokio::time::timeout(Duration::from_secs(1), updates.changed())
+            .await
+            .expect("changed should return closed after pending update is observed");
+        assert!(matches!(result, Err(X509SourceError::Closed)));
+    }
+
+    #[tokio::test]
+    async fn test_updates_changed_returns_closed_after_last_source_drop() {
+        let source = X509Source::new_for_test(
+            test_x509_context(),
+            ReconnectConfig::default(),
+            ResourceLimits::default(),
+            None,
+            None,
+        );
+        let mut updates = source.updated();
+
+        drop(source);
+
+        let result = tokio::time::timeout(Duration::from_secs(1), updates.changed())
+            .await
+            .expect("changed should return after last source handle is dropped");
+        assert!(matches!(result, Err(X509SourceError::Closed)));
+    }
+
+    #[tokio::test]
+    async fn test_dropping_last_source_handle_cancels_supervisor_token() {
+        let source = X509Source::new_for_test(
+            test_x509_context(),
+            ReconnectConfig::default(),
+            ResourceLimits::default(),
+            None,
+            None,
+        );
+        let clone = source.clone();
+        let task_inner = Arc::clone(&source.inner);
+        let token = task_inner.cancel.clone();
+        let (stopped_tx, stopped_rx) = tokio::sync::oneshot::channel();
+
+        tokio::spawn(async move {
+            token.cancelled().await;
+            let _unused: Result<_, _> = stopped_tx.send(());
+            drop(task_inner);
+        });
+
+        drop(source);
+        // One public handle still holds the shutdown guard, so cancellation must not fire yet.
+        assert!(!clone.inner.cancel.is_cancelled());
+
+        drop(clone);
+        tokio::time::timeout(Duration::from_secs(1), stopped_rx)
+            .await
+            .expect("supervisor token should be cancelled when last source handle is dropped")
+            .expect("supervisor observer should send stop notification");
     }
 
     /// Test metrics recorder that counts error recordings by kind.

--- a/spiffe/tests/jwt_source.rs
+++ b/spiffe/tests/jwt_source.rs
@@ -563,13 +563,27 @@ mod integration_tests_jwt_source {
             "Sequence should not change immediately after shutdown"
         );
 
-        // Use a timeout to verify no updates come after shutdown
-        // If changed() completes, that means an update occurred (which shouldn't happen)
-        let update_occurred = tokio::time::timeout(Duration::from_millis(100), updates.changed())
+        let result = tokio::time::timeout(Duration::from_secs(1), updates.changed())
             .await
-            .is_ok();
+            .expect("changed() should report closure after shutdown");
+        match result {
+            Ok(seq) => {
+                assert_eq!(
+                    seq, seq_before,
+                    "Only an already-pending update may be observed after shutdown"
+                );
 
-        assert!(!update_occurred, "No updates should occur after shutdown");
+                let closed = tokio::time::timeout(Duration::from_secs(1), updates.changed())
+                    .await
+                    .expect("changed() should report closure after pending update");
+                assert!(matches!(
+                    closed,
+                    Err(spiffe::jwt_source::JwtSourceError::Closed)
+                ));
+            }
+            Err(spiffe::jwt_source::JwtSourceError::Closed) => {}
+            Err(err) => panic!("Unexpected update error after shutdown: {err}"),
+        }
 
         let seq_after = updates.last();
         assert_eq!(

--- a/spiffe/tests/x509_source.rs
+++ b/spiffe/tests/x509_source.rs
@@ -617,13 +617,27 @@ mod integration_tests_x509_source {
             "Sequence should not change immediately after shutdown"
         );
 
-        // Use a timeout to verify no updates come after shutdown
-        // If changed() completes, that means an update occurred (which shouldn't happen)
-        let update_occurred = tokio::time::timeout(Duration::from_millis(100), updates.changed())
+        let result = tokio::time::timeout(Duration::from_secs(1), updates.changed())
             .await
-            .is_ok();
+            .expect("changed() should report closure after shutdown");
+        match result {
+            Ok(seq) => {
+                assert_eq!(
+                    seq, seq_before,
+                    "Only an already-pending update may be observed after shutdown"
+                );
 
-        assert!(!update_occurred, "No updates should occur after shutdown");
+                let closed = tokio::time::timeout(Duration::from_secs(1), updates.changed())
+                    .await
+                    .expect("changed() should report closure after pending update");
+                assert!(matches!(
+                    closed,
+                    Err(spiffe::x509_source::X509SourceError::Closed)
+                ));
+            }
+            Err(spiffe::x509_source::X509SourceError::Closed) => {}
+            Err(err) => panic!("Unexpected update error after shutdown: {err}"),
+        }
 
         let seq_after = updates.last();
         assert_eq!(


### PR DESCRIPTION
## Context
`X509Source` and `JwtSource` spawned supervisor tasks that could keep `Arc<Inner>` alive after the last public source handle was dropped. Update waiters could also block indefinitely after shutdown because they only waited on the watch channel.

## Changes
- Move last-handle cancellation to a source-owned `DropGuard`, separate from the task-owned `Arc<Inner>`.
- Add a task-local `DropGuard` so supervisor termination, including panic paths, closes update waiters.
- Make `changed()` / `wait_for()` observe shutdown directly and return `Closed`.
- Preserve pending update delivery before returning `Closed`.
- Add regression tests for X.509 and JWT source shutdown/drop behavior.

## Security
- Advisory: none
- Fix: prevents leaked source supervisor tasks and hanging update waiters after source shutdown/drop.

## Compatibility
- MSRV: unchanged
- Breaking changes: none
- Affected crates/features (if applicable): `spiffe` with `x509-source` and `jwt-source`

## Testing
- `cargo test -p spiffe --features x509-source,jwt-source x509_source::source::tests`
- `cargo test -p spiffe --features x509-source,jwt-source jwt_source::source::tests`

## Release notes
- Fixed `X509Source` and `JwtSource` shutdown/drop lifecycle behavior so supervisors stop when the last source handle is dropped and update waiters return `Closed` on shutdown.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxlambrecht/rust-spiffe/333)
<!-- Reviewable:end -->
