### PR TITLE
fix(spiffe): notify source subscribers before success metrics

### DIFF
--- a/spiffe/src/jwt_source/metrics.rs
+++ b/spiffe/src/jwt_source/metrics.rs
@@ -4,6 +4,7 @@ use super::errors::MetricsErrorKind;
 ///
 /// Implement this trait to integrate with your metrics system (e.g., Prometheus, `StatsD`).
 /// Prefer stable, low-cardinality labels when recording metrics.
+/// Implementations must not panic.
 ///
 /// # Example
 ///

--- a/spiffe/src/jwt_source/source.rs
+++ b/spiffe/src/jwt_source/source.rs
@@ -780,8 +780,8 @@ impl Inner {
         match self.validate_bundle_set(&new_bundle_set) {
             Ok(()) => {
                 self.bundle_set.store(new_bundle_set);
-                self.record_update();
                 self.notify_update();
+                self.record_update();
                 Ok(())
             }
             Err(e) => {
@@ -1189,6 +1189,117 @@ mod tests {
         fn record_error(&self, kind: MetricsErrorKind) {
             *self.counts.lock().unwrap().entry(kind).or_insert(0) += 1;
         }
+    }
+
+    struct OrderingMetricsRecorder {
+        updates: Mutex<Option<JwtSourceUpdates>>,
+        update_sequences: Mutex<Vec<Option<u64>>>,
+    }
+
+    impl OrderingMetricsRecorder {
+        fn new() -> Self {
+            Self {
+                updates: Mutex::new(None),
+                update_sequences: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn set_updates(&self, updates: JwtSourceUpdates) {
+            *self.updates.lock().unwrap() = Some(updates);
+        }
+
+        fn update_sequences(&self) -> Vec<Option<u64>> {
+            self.update_sequences.lock().unwrap().clone()
+        }
+
+        fn record_observed_update(&self) {
+            let sequence = self
+                .updates
+                .lock()
+                .unwrap()
+                .as_ref()
+                .map(JwtSourceUpdates::last);
+            self.update_sequences.lock().unwrap().push(sequence);
+        }
+    }
+
+    impl MetricsRecorder for OrderingMetricsRecorder {
+        fn record_update(&self) {
+            self.record_observed_update();
+        }
+
+        fn record_reconnect(&self) {}
+        fn record_error(&self, _kind: MetricsErrorKind) {}
+    }
+
+    struct PanickingOrderingMetricsRecorder {
+        inner: OrderingMetricsRecorder,
+    }
+
+    impl PanickingOrderingMetricsRecorder {
+        fn new() -> Self {
+            Self {
+                inner: OrderingMetricsRecorder::new(),
+            }
+        }
+
+        fn set_updates(&self, updates: JwtSourceUpdates) {
+            self.inner.set_updates(updates);
+        }
+
+        fn update_sequences(&self) -> Vec<Option<u64>> {
+            self.inner.update_sequences()
+        }
+    }
+
+    impl MetricsRecorder for PanickingOrderingMetricsRecorder {
+        fn record_update(&self) {
+            self.inner.record_observed_update();
+            panic!("intentional metrics panic for update ordering test");
+        }
+
+        fn record_reconnect(&self) {}
+        fn record_error(&self, _kind: MetricsErrorKind) {}
+    }
+
+    #[test]
+    fn test_apply_update_notifies_before_recording_success_metrics() {
+        let metrics = Arc::new(OrderingMetricsRecorder::new());
+        let source = JwtSource::new_for_test(
+            Arc::new(JwtBundleSet::new()),
+            ReconnectConfig::default(),
+            ResourceLimits::default(),
+            Some(Arc::<OrderingMetricsRecorder>::clone(&metrics)),
+        );
+        metrics.set_updates(source.updated());
+
+        let result = source.inner.apply_update(create_test_bundle_set());
+
+        result.expect("valid JWT bundle set update should be accepted");
+        assert_eq!(metrics.update_sequences(), vec![Some(1)]);
+        assert_eq!(source.updated().last(), 1);
+        assert_eq!(source.bundle_set().unwrap().iter().count(), 1);
+    }
+
+    #[test]
+    fn test_apply_update_publishes_and_notifies_before_panicking_success_metrics() {
+        let metrics = Arc::new(PanickingOrderingMetricsRecorder::new());
+        let source = JwtSource::new_for_test(
+            Arc::new(JwtBundleSet::new()),
+            ReconnectConfig::default(),
+            ResourceLimits::default(),
+            Some(Arc::<PanickingOrderingMetricsRecorder>::clone(&metrics)),
+        );
+        metrics.set_updates(source.updated());
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            source.inner.apply_update(create_test_bundle_set())
+        }));
+
+        result.expect_err("metrics recorder should panic after notification");
+        assert_eq!(metrics.update_sequences(), vec![Some(1)]);
+        assert_eq!(source.updated().last(), 1);
+        assert_eq!(source.bundle_set().unwrap().iter().count(), 1);
     }
 
     #[test]

--- a/spiffe/src/x509_source/metrics.rs
+++ b/spiffe/src/x509_source/metrics.rs
@@ -4,6 +4,7 @@ use super::errors::MetricsErrorKind;
 ///
 /// Implement this trait to integrate with your metrics system (e.g., Prometheus, `StatsD`).
 /// Prefer stable, low-cardinality labels when recording metrics.
+/// Implementations must not panic.
 ///
 /// # Example
 ///

--- a/spiffe/src/x509_source/source.rs
+++ b/spiffe/src/x509_source/source.rs
@@ -698,8 +698,8 @@ impl Inner {
                     ctx: new_ctx,
                     expiry_unix: svid.expiry_unix(),
                 }));
-                self.record_update();
                 self.notify_update();
+                self.record_update();
                 Ok(())
             }
             Err(e) => {
@@ -1100,6 +1100,119 @@ mod tests {
         fn record_error(&self, kind: MetricsErrorKind) {
             *self.counts.lock().unwrap().entry(kind).or_insert(0) += 1;
         }
+    }
+
+    struct OrderingMetricsRecorder {
+        updates: Mutex<Option<X509SourceUpdates>>,
+        update_sequences: Mutex<Vec<Option<u64>>>,
+    }
+
+    impl OrderingMetricsRecorder {
+        fn new() -> Self {
+            Self {
+                updates: Mutex::new(None),
+                update_sequences: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn set_updates(&self, updates: X509SourceUpdates) {
+            *self.updates.lock().unwrap() = Some(updates);
+        }
+
+        fn update_sequences(&self) -> Vec<Option<u64>> {
+            self.update_sequences.lock().unwrap().clone()
+        }
+
+        fn record_observed_update(&self) {
+            let sequence = self
+                .updates
+                .lock()
+                .unwrap()
+                .as_ref()
+                .map(X509SourceUpdates::last);
+            self.update_sequences.lock().unwrap().push(sequence);
+        }
+    }
+
+    impl MetricsRecorder for OrderingMetricsRecorder {
+        fn record_update(&self) {
+            self.record_observed_update();
+        }
+
+        fn record_reconnect(&self) {}
+        fn record_error(&self, _kind: MetricsErrorKind) {}
+    }
+
+    struct PanickingOrderingMetricsRecorder {
+        inner: OrderingMetricsRecorder,
+    }
+
+    impl PanickingOrderingMetricsRecorder {
+        fn new() -> Self {
+            Self {
+                inner: OrderingMetricsRecorder::new(),
+            }
+        }
+
+        fn set_updates(&self, updates: X509SourceUpdates) {
+            self.inner.set_updates(updates);
+        }
+
+        fn update_sequences(&self) -> Vec<Option<u64>> {
+            self.inner.update_sequences()
+        }
+    }
+
+    impl MetricsRecorder for PanickingOrderingMetricsRecorder {
+        fn record_update(&self) {
+            self.inner.record_observed_update();
+            panic!("intentional metrics panic for update ordering test");
+        }
+
+        fn record_reconnect(&self) {}
+        fn record_error(&self, _kind: MetricsErrorKind) {}
+    }
+
+    #[test]
+    fn test_apply_update_notifies_before_recording_success_metrics() {
+        let metrics = Arc::new(OrderingMetricsRecorder::new());
+        let source = X509Source::new_for_test(
+            Arc::new(X509Context::new([], Arc::new(X509BundleSet::new()))),
+            ReconnectConfig::default(),
+            ResourceLimits::default(),
+            Some(Arc::<OrderingMetricsRecorder>::clone(&metrics)),
+            None,
+        );
+        metrics.set_updates(source.updated());
+
+        let result = source.inner.apply_update(test_x509_context());
+
+        result.expect("valid X.509 update should be accepted");
+        assert_eq!(metrics.update_sequences(), vec![Some(1)]);
+        assert_eq!(source.updated().last(), 1);
+        assert_eq!(source.x509_context().unwrap().svids().len(), 1);
+    }
+
+    #[test]
+    fn test_apply_update_publishes_and_notifies_before_panicking_success_metrics() {
+        let metrics = Arc::new(PanickingOrderingMetricsRecorder::new());
+        let source = X509Source::new_for_test(
+            Arc::new(X509Context::new([], Arc::new(X509BundleSet::new()))),
+            ReconnectConfig::default(),
+            ResourceLimits::default(),
+            Some(Arc::<PanickingOrderingMetricsRecorder>::clone(&metrics)),
+            None,
+        );
+        metrics.set_updates(source.updated());
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            source.inner.apply_update(test_x509_context())
+        }));
+
+        result.expect_err("metrics recorder should panic after notification");
+        assert_eq!(metrics.update_sequences(), vec![Some(1)]);
+        assert_eq!(source.updated().last(), 1);
+        assert_eq!(source.x509_context().unwrap().svids().len(), 1);
     }
 
     #[test]

--- a/spiffe/src/x509_source/types.rs
+++ b/spiffe/src/x509_source/types.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 ///
 /// Implement this trait to customize SVID selection logic. The picker is called whenever
 /// a new X.509 context is received from the Workload API.
+/// Implementations must not panic.
 ///
 /// # Example
 ///


### PR DESCRIPTION
## Context
Harden `x509_source` and `jwt_source` update handling so subscribers cannot miss a successfully accepted source update because success metrics panic or otherwise fail.

## Changes
- Reordered accepted update handling to publish/store state, notify subscribers, then record success metrics.
- Applied the same ordering to both `X509Source` and `JwtSource`.
- Documented that user-provided metrics recorders and the X.509 SVID picker must not panic.
- Added focused tests covering notification ordering with metrics present and with panicking success metrics.

## Security
- Advisory: none
- Fix: preserves subscriber visibility for accepted source updates even if non-essential success metrics panic after publication.

## Compatibility
- MSRV: unchanged
- Breaking changes: none
- Affected crates/features (if applicable): `spiffe` with `x509-source`, `jwt-source`

## Testing
- `cargo fmt --package spiffe`
- `cargo test -p spiffe --features x509-source,jwt-source apply_update_`
- `cargo test -p spiffe --features x509-source,jwt-source x509_source`
- `cargo test -p spiffe --features x509-source,jwt-source jwt_source`
- `cargo test -p spiffe --features x509-source,jwt-source`

## Release notes
- Hardened `X509Source` and `JwtSource` update notification ordering so accepted updates are published and notified before success metrics are recorded.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxlambrecht/rust-spiffe/336)
<!-- Reviewable:end -->
