### PR TITLE
fix(spiffe): harden source lifecycle checks

### DIFF
--- a/spiffe/src/jwt_source/builder.rs
+++ b/spiffe/src/jwt_source/builder.rs
@@ -147,6 +147,14 @@ impl ResourceLimits {
 /// Builder for [`JwtSource`].
 ///
 /// Use this when you need explicit configuration (socket path, backoff, resource limits).
+/// By default, `build()` waits until initial synchronization succeeds or returns a
+/// non-retryable error according to the source's existing behavior. Use
+/// [`JwtSourceBuilder::initial_sync_timeout`] to opt into bounding only that construction-time
+/// initial sync.
+///
+/// Construction may succeed even if the current bundle set contains no JWT signing
+/// authorities. In that case, [`JwtSource::is_healthy`] may immediately report `false`
+/// until the agent publishes usable authorities.
 ///
 /// # Example
 ///
@@ -173,6 +181,7 @@ pub struct JwtSourceBuilder {
     limits: ResourceLimits,
     metrics: Option<Arc<dyn MetricsRecorder>>,
     shutdown_timeout: Option<Duration>,
+    initial_sync_timeout: Option<Duration>,
 }
 
 impl Debug for JwtSourceBuilder {
@@ -189,6 +198,7 @@ impl Debug for JwtSourceBuilder {
                 &self.metrics.as_ref().map(|_| "<MetricsRecorder>"),
             )
             .field("shutdown_timeout", &self.shutdown_timeout)
+            .field("initial_sync_timeout", &self.initial_sync_timeout)
             .finish()
     }
 }
@@ -220,6 +230,7 @@ impl JwtSourceBuilder {
             limits: ResourceLimits::default(),
             metrics: None,
             shutdown_timeout: Some(Duration::from_secs(30)),
+            initial_sync_timeout: None,
         }
     }
 
@@ -361,15 +372,46 @@ impl JwtSourceBuilder {
         self
     }
 
+    /// Sets an optional timeout for the initial synchronization performed by `build()`.
+    ///
+    /// By default this is `None`, preserving the existing behavior: source construction waits
+    /// until initial sync succeeds or returns a non-retryable error according to the source's
+    /// existing retry behavior.
+    ///
+    /// When configured, the timeout bounds only the initial sync performed during source
+    /// construction. It does not bound future background reconnects or update retries after the
+    /// source has been constructed.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use spiffe::jwt_source::JwtSourceBuilder;
+    /// use std::time::Duration;
+    ///
+    /// let builder = JwtSourceBuilder::new()
+    ///     .initial_sync_timeout(Duration::from_secs(10));
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    #[must_use]
+    pub const fn initial_sync_timeout(mut self, timeout: Duration) -> Self {
+        self.initial_sync_timeout = Some(timeout);
+        self
+    }
+
     /// Builds a ready-to-use [`JwtSource`].
     ///
     /// On success, the returned source has completed an initial synchronization with
     /// the Workload API and will continue updating in the background.
+    /// The initial bundle set may contain no JWT signing authorities; in that case,
+    /// [`JwtSource::is_healthy`] may report `false` until usable authorities arrive.
+    /// The on-demand JWT SVID client is created lazily on the first
+    /// [`JwtSource::get_jwt_svid`] call, so client-creation failures for on-demand
+    /// JWT SVID fetching are reported by `get_jwt_svid` rather than `build`.
     ///
     /// # Errors
     ///
     /// Returns a [`JwtSourceError`] if the Workload API endpoint cannot be resolved
-    /// or connected to, or the initial synchronization fails.
+    /// or connected to, or the initial synchronization fails or times out.
     pub async fn build(self) -> Result<JwtSource, JwtSourceError> {
         let make_client = self.make_client.unwrap_or_else(|| {
             Arc::new(|| Box::pin(async { WorkloadApiClient::connect_env().await }))
@@ -381,6 +423,7 @@ impl JwtSourceBuilder {
             self.limits,
             self.metrics,
             self.shutdown_timeout,
+            self.initial_sync_timeout,
         )
         .await
     }
@@ -429,6 +472,18 @@ mod tests {
         // Builder stores raw values; normalization happens later at the boundary
         assert_eq!(builder.reconnect.min_backoff, Duration::from_secs(10));
         assert_eq!(builder.reconnect.max_backoff, Duration::from_secs(1));
+    }
+
+    #[test]
+    fn initial_sync_timeout_defaults_to_none() {
+        let builder = JwtSourceBuilder::new();
+        assert_eq!(builder.initial_sync_timeout, None);
+    }
+
+    #[test]
+    fn initial_sync_timeout_setter_stores_timeout() {
+        let builder = JwtSourceBuilder::new().initial_sync_timeout(Duration::from_secs(5));
+        assert_eq!(builder.initial_sync_timeout, Some(Duration::from_secs(5)));
     }
 
     #[test]

--- a/spiffe/src/jwt_source/errors.rs
+++ b/spiffe/src/jwt_source/errors.rs
@@ -21,6 +21,14 @@ pub enum JwtSourceError {
     #[error("source is closed")]
     Closed,
 
+    /// Initial synchronization timeout exceeded.
+    ///
+    /// This error occurs when `JwtSourceBuilder::initial_sync_timeout()` is configured
+    /// and the initial synchronization performed during source construction does not
+    /// complete within the specified timeout.
+    #[error("initial synchronization timed out")]
+    InitialSyncTimeout,
+
     /// The workload API stream ended.
     ///
     /// This error occurs when the gRPC stream from the Workload API terminates

--- a/spiffe/src/jwt_source/source.rs
+++ b/spiffe/src/jwt_source/source.rs
@@ -10,6 +10,7 @@ use crate::workload_api::WorkloadApiClient;
 use crate::{JwtBundle, JwtBundleSet, JwtSvid, SpiffeId, TrustDomain};
 use arc_swap::ArcSwap;
 use std::fmt::Debug;
+use std::future::Future;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -104,9 +105,10 @@ impl JwtSourceUpdates {
 
     /// Waits for the sequence number to satisfy a predicate.
     ///
-    /// This method first checks the current sequence number; if the predicate
-    /// is already satisfied, it returns immediately without waiting. Otherwise,
-    /// it repeatedly calls `changed()` until the predicate returns `true`.
+    /// This method first checks whether the source is closed, then checks the
+    /// current sequence number; if the predicate is already satisfied, it returns
+    /// immediately without waiting. Otherwise, it repeatedly calls `changed()`
+    /// until the predicate returns `true`.
     ///
     /// # Errors
     ///
@@ -115,6 +117,10 @@ impl JwtSourceUpdates {
     where
         F: FnMut(&u64) -> bool,
     {
+        if self.shutdown.is_cancelled() {
+            return Err(JwtSourceError::Closed);
+        }
+
         let current = self.last();
         if f(&current) {
             return Ok(current);
@@ -357,6 +363,14 @@ impl JwtSource {
     /// `bundle_set()`, the source may be shut down or the bundle set may change. Use this
     /// for best-effort health checks (e.g., monitoring), not for synchronization.
     /// If you need a guaranteed check, call `bundle_set()` directly and handle the error.
+    /// `build()` / builder `build()` only indicates that initial sync completed successfully;
+    /// `is_healthy()` is a runtime health signal, not a construction-success signal. There
+    /// may be a brief scheduler-dependent window immediately after construction where this
+    /// method returns `false` until the background supervisor task is first polled.
+    ///
+    /// If a [`MetricsRecorder`] callback panics, the supervisor task terminates, update
+    /// handles close, and this method reports `false` afterward. Rebuild the source to
+    /// resume updates.
     ///
     /// # Examples
     ///
@@ -619,40 +633,36 @@ impl JwtSource {
     }
 }
 
+struct BuildParts {
+    make_client: ClientFactory,
+    reconnect: ReconnectConfig,
+    limits: ResourceLimits,
+    metrics: Option<Arc<dyn MetricsRecorder>>,
+    shutdown_timeout: Option<Duration>,
+    cancel: CancellationToken,
+    shutdown_guard: Arc<DropGuard>,
+    update_tx: watch::Sender<u64>,
+}
+
 impl JwtSource {
-    pub(super) async fn build_with(
-        make_client: ClientFactory,
-        reconnect: ReconnectConfig,
-        limits: ResourceLimits,
-        metrics: Option<Arc<dyn MetricsRecorder>>,
-        shutdown_timeout: Option<Duration>,
-    ) -> Result<Self, JwtSourceError> {
-        let reconnect = super::builder::normalize_reconnect(reconnect);
-
-        let (update_tx, _update_rx) = watch::channel(0u64);
-        let cancel = CancellationToken::new();
-        let shutdown_guard = Arc::new(cancel.clone().drop_guard());
-
-        let initial_bundle_set =
-            initial_sync_with_retry(&make_client, &cancel, reconnect, limits, metrics.as_deref())
-                .await?;
-
-        // Create initial client for on-demand SVID fetching.
-        // Retry once after a short delay if the first attempt fails, because the
-        // initial sync (which also creates clients internally) already succeeded,
-        // so a failure here is likely transient.
-        let initial_client = match make_client().await {
-            Ok(c) => c,
-            Err(_first_err) => {
-                tokio::time::sleep(reconnect.min_backoff).await;
-                make_client().await.map_err(JwtSourceError::Source)?
-            }
-        };
-        let initial_client_arc = Arc::new(initial_client);
+    async fn build_from_synced_bundle_set(
+        parts: BuildParts,
+        initial_bundle_set: Arc<JwtBundleSet>,
+    ) -> Self {
+        let BuildParts {
+            make_client,
+            reconnect,
+            limits,
+            metrics,
+            shutdown_timeout,
+            cancel,
+            shutdown_guard,
+            update_tx,
+        } = parts;
 
         let inner = Arc::new(Inner {
             bundle_set: ArcSwap::from(initial_bundle_set),
-            cached_client: ArcSwap::from(Arc::new(Some(initial_client_arc))),
+            cached_client: ArcSwap::from(Arc::new(None)),
             client_creation_mutex: Mutex::new(()),
             reconnect,
             make_client,
@@ -669,19 +679,73 @@ impl JwtSource {
 
         let task_inner = Arc::clone(&inner);
         let token = task_inner.cancel.clone();
-        let terminate_guard =
-            SupervisorTerminationGuard::new(Arc::clone(&task_inner), token.clone());
+        let guard_inner = Arc::clone(&task_inner);
         let handle = tokio::spawn(async move {
-            let _terminate_on_drop = terminate_guard;
+            let _terminate_on_drop = SupervisorTerminationGuard::new(guard_inner);
             task_inner.run_update_supervisor(token).await;
         });
 
         *inner.supervisor.lock().await = Some(handle);
 
-        Ok(Self {
+        Self {
             inner,
             _shutdown_guard: shutdown_guard,
-        })
+        }
+    }
+
+    async fn build_with_initial_sync<F>(
+        parts: BuildParts,
+        initial_sync_timeout: Option<Duration>,
+        initial_sync: F,
+    ) -> Result<Self, JwtSourceError>
+    where
+        F: Future<Output = Result<Arc<JwtBundleSet>, JwtSourceError>>,
+    {
+        let initial_bundle_set =
+            initial_sync_with_timeout(initial_sync, &parts.cancel, initial_sync_timeout).await?;
+
+        Ok(Self::build_from_synced_bundle_set(parts, initial_bundle_set).await)
+    }
+
+    pub(super) async fn build_with(
+        make_client: ClientFactory,
+        reconnect: ReconnectConfig,
+        limits: ResourceLimits,
+        metrics: Option<Arc<dyn MetricsRecorder>>,
+        shutdown_timeout: Option<Duration>,
+        initial_sync_timeout: Option<Duration>,
+    ) -> Result<Self, JwtSourceError> {
+        let reconnect = super::builder::normalize_reconnect(reconnect);
+
+        let (update_tx, _update_rx) = watch::channel(0u64);
+        let cancel = CancellationToken::new();
+        let shutdown_guard = Arc::new(cancel.clone().drop_guard());
+        let initial_sync_make_client = Arc::clone(&make_client);
+        let initial_sync_cancel = cancel.clone();
+        let initial_sync_metrics = metrics.clone();
+        let initial_sync = async move {
+            initial_sync_with_retry(
+                &initial_sync_make_client,
+                &initial_sync_cancel,
+                reconnect,
+                limits,
+                initial_sync_metrics.as_deref(),
+            )
+            .await
+        };
+
+        let parts = BuildParts {
+            make_client,
+            reconnect,
+            limits,
+            metrics,
+            shutdown_timeout,
+            cancel,
+            shutdown_guard,
+            update_tx,
+        };
+
+        Self::build_with_initial_sync(parts, initial_sync_timeout, initial_sync).await
     }
 
     /// Test-only constructor that creates a `JwtSource` with a provided initial bundle set
@@ -738,13 +802,12 @@ impl JwtSource {
 
 struct SupervisorTerminationGuard {
     inner: Arc<Inner>,
-    token: CancellationToken,
 }
 
 impl SupervisorTerminationGuard {
-    fn new(inner: Arc<Inner>, token: CancellationToken) -> Self {
+    fn new(inner: Arc<Inner>) -> Self {
         inner.supervisor_running.store(true, Ordering::Release);
-        Self { inner, token }
+        Self { inner }
     }
 }
 
@@ -753,7 +816,7 @@ impl Drop for SupervisorTerminationGuard {
         self.inner
             .supervisor_running
             .store(false, Ordering::Release);
-        self.token.cancel();
+        self.inner.cancel.cancel();
     }
 }
 
@@ -802,6 +865,27 @@ impl Inner {
         bundle_set: &JwtBundleSet,
     ) -> Result<(), JwtSourceError> {
         validate_bundle_set(bundle_set, self.limits, self.metrics.as_deref())
+    }
+}
+
+async fn initial_sync_with_timeout<T, F>(
+    initial_sync: F,
+    cancel: &CancellationToken,
+    timeout: Option<Duration>,
+) -> Result<T, JwtSourceError>
+where
+    F: Future<Output = Result<T, JwtSourceError>>,
+{
+    let Some(timeout) = timeout else {
+        return initial_sync.await;
+    };
+
+    match tokio::time::timeout(timeout, initial_sync).await {
+        Ok(result) => result,
+        Err(_elapsed) => {
+            cancel.cancel();
+            Err(JwtSourceError::InitialSyncTimeout)
+        }
     }
 }
 
@@ -862,9 +946,7 @@ mod tests {
     }
 
     fn supervisor_running_guard_for_test(source: &JwtSource) -> SupervisorTerminationGuard {
-        let task_inner = Arc::clone(&source.inner);
-        let token = task_inner.cancel.clone();
-        SupervisorTerminationGuard::new(task_inner, token)
+        SupervisorTerminationGuard::new(Arc::clone(&source.inner))
     }
 
     async fn terminate_supervisor_for_test(terminate_guard: SupervisorTerminationGuard) {
@@ -873,6 +955,93 @@ mod tests {
         })
         .await
         .expect("supervisor termination task should not panic");
+    }
+
+    #[tokio::test]
+    async fn initial_sync_timeout_returns_timeout_and_cancels_token() {
+        let cancel = CancellationToken::new();
+
+        let result = initial_sync_with_timeout(
+            std::future::pending::<Result<(), JwtSourceError>>(),
+            &cancel,
+            Some(Duration::ZERO),
+        )
+        .await;
+
+        assert!(matches!(result, Err(JwtSourceError::InitialSyncTimeout)));
+        assert!(cancel.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn initial_sync_timeout_allows_success_before_timeout() {
+        let cancel = CancellationToken::new();
+
+        let result = initial_sync_with_timeout(
+            async { Ok::<_, JwtSourceError>("synced") },
+            &cancel,
+            Some(Duration::from_secs(60)),
+        )
+        .await;
+
+        assert_eq!(result.unwrap(), "synced");
+        assert!(!cancel.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn initial_sync_without_timeout_waits_for_future() {
+        let cancel = CancellationToken::new();
+
+        let result =
+            initial_sync_with_timeout(async { Ok::<_, JwtSourceError>("synced") }, &cancel, None)
+                .await;
+
+        assert_eq!(result.unwrap(), "synced");
+        assert!(!cancel.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn build_with_initial_sync_timeout_does_not_eagerly_create_jwt_client() {
+        let (update_tx, _update_rx) = watch::channel(0u64);
+        let cancel = CancellationToken::new();
+        let shutdown_guard = Arc::new(cancel.clone().drop_guard());
+        let make_client: ClientFactory = Arc::new(|| {
+            Box::pin(async {
+                std::future::pending::<Result<WorkloadApiClient, WorkloadApiError>>().await
+            })
+        });
+
+        let source = tokio::time::timeout(
+            Duration::from_millis(100),
+            JwtSource::build_with_initial_sync(
+                BuildParts {
+                    make_client,
+                    reconnect: ReconnectConfig {
+                        min_backoff: Duration::from_millis(10),
+                        max_backoff: Duration::from_millis(10),
+                    },
+                    limits: ResourceLimits::default(),
+                    metrics: None,
+                    shutdown_timeout: Some(Duration::from_millis(10)),
+                    cancel,
+                    shutdown_guard,
+                    update_tx,
+                },
+                Some(Duration::from_millis(50)),
+                async { Ok::<_, JwtSourceError>(create_test_bundle_set()) },
+            ),
+        )
+        .await
+        .expect("build_with post-initial-sync path should not wait on on-demand client creation")
+        .expect("initial sync should succeed before timeout");
+
+        assert!(
+            source.inner.cached_client.load().is_none(),
+            "on-demand JWT client should start empty and be created lazily"
+        );
+
+        let _unused = source
+            .shutdown_with_timeout(Duration::from_millis(10))
+            .await;
     }
 
     #[tokio::test]
@@ -1023,6 +1192,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn wait_for_returns_closed_after_shutdown_even_when_predicate_matches_current() {
+        let source = JwtSource::new_for_test(
+            create_test_bundle_set(),
+            ReconnectConfig::default(),
+            ResourceLimits::default(),
+            None,
+        );
+        let mut updates = source.updated();
+        let current = updates.last();
+
+        source.shutdown().await;
+
+        let result = updates.wait_for(|seq| *seq == current).await;
+        assert!(matches!(result, Err(JwtSourceError::Closed)));
+    }
+
+    #[tokio::test]
     async fn test_updates_changed_delivers_pending_update_before_closed() {
         let source = JwtSource::new_for_test(
             create_test_bundle_set(),
@@ -1127,6 +1313,25 @@ mod tests {
         assert!(matches!(waited, Err(JwtSourceError::Closed)));
     }
 
+    #[tokio::test]
+    async fn wait_for_returns_closed_after_supervisor_termination_even_when_predicate_matches_current(
+    ) {
+        let source = JwtSource::new_for_test(
+            create_test_bundle_set(),
+            ReconnectConfig::default(),
+            ResourceLimits::default(),
+            None,
+        );
+        let running_guard = supervisor_running_guard_for_test(&source);
+        let mut updates = source.updated();
+        let current = updates.last();
+
+        terminate_supervisor_for_test(running_guard).await;
+
+        let result = updates.wait_for(|seq| *seq == current).await;
+        assert!(matches!(result, Err(JwtSourceError::Closed)));
+    }
+
     #[test]
     fn test_is_healthy_false_when_bundle_set_is_empty() {
         let source = JwtSource::new_for_test(
@@ -1164,6 +1369,36 @@ mod tests {
         );
         let _guard = supervisor_running_guard_for_test(&source);
         assert!(source.is_healthy());
+    }
+
+    #[tokio::test]
+    async fn is_healthy_false_after_shutdown() {
+        let source = JwtSource::new_for_test(
+            create_test_bundle_set(),
+            ReconnectConfig::default(),
+            ResourceLimits::default(),
+            None,
+        );
+        let _guard = supervisor_running_guard_for_test(&source);
+
+        assert!(source.is_healthy());
+        source.shutdown().await;
+        assert!(!source.is_healthy());
+    }
+
+    #[test]
+    fn is_healthy_false_after_cancel() {
+        let source = JwtSource::new_for_test(
+            create_test_bundle_set(),
+            ReconnectConfig::default(),
+            ResourceLimits::default(),
+            None,
+        );
+        let _guard = supervisor_running_guard_for_test(&source);
+
+        assert!(source.is_healthy());
+        source.inner.cancel.cancel();
+        assert!(!source.is_healthy());
     }
 
     /// Test metrics recorder that counts error recordings by kind.

--- a/spiffe/src/x509_source/builder.rs
+++ b/spiffe/src/x509_source/builder.rs
@@ -158,6 +158,10 @@ impl ResourceLimits {
 /// Builder for [`X509Source`].
 ///
 /// Use this when you need explicit configuration (socket path, picker, backoff, resource limits).
+/// By default, `build()` waits until initial synchronization succeeds or returns a
+/// non-retryable error according to the source's existing behavior. Use
+/// [`X509SourceBuilder::initial_sync_timeout`] to opt into bounding only that construction-time
+/// initial sync.
 ///
 /// # Example
 ///
@@ -186,6 +190,7 @@ pub struct X509SourceBuilder {
     limits: ResourceLimits,
     metrics: Option<Arc<dyn MetricsRecorder>>,
     shutdown_timeout: Option<Duration>,
+    initial_sync_timeout: Option<Duration>,
 }
 
 impl Debug for X509SourceBuilder {
@@ -206,6 +211,7 @@ impl Debug for X509SourceBuilder {
                 &self.metrics.as_ref().map(|_| "<MetricsRecorder>"),
             )
             .field("shutdown_timeout", &self.shutdown_timeout)
+            .field("initial_sync_timeout", &self.initial_sync_timeout)
             .finish()
     }
 }
@@ -238,6 +244,7 @@ impl X509SourceBuilder {
             limits: ResourceLimits::default(),
             metrics: None,
             shutdown_timeout: Some(Duration::from_secs(30)),
+            initial_sync_timeout: None,
         }
     }
 
@@ -421,6 +428,32 @@ impl X509SourceBuilder {
         self
     }
 
+    /// Sets an optional timeout for the initial synchronization performed by `build()`.
+    ///
+    /// By default this is `None`, preserving the existing behavior: source construction waits
+    /// until initial sync succeeds or returns a non-retryable error according to the source's
+    /// existing retry behavior.
+    ///
+    /// When configured, the timeout bounds only the initial sync performed during source
+    /// construction. It does not bound future background reconnects or update retries after the
+    /// source has been constructed.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use spiffe::X509SourceBuilder;
+    /// use std::time::Duration;
+    ///
+    /// let builder = X509SourceBuilder::new()
+    ///     .initial_sync_timeout(Duration::from_secs(10));
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    #[must_use]
+    pub const fn initial_sync_timeout(mut self, timeout: Duration) -> Self {
+        self.initial_sync_timeout = Some(timeout);
+        self
+    }
+
     /// Builds a ready-to-use [`X509Source`].
     ///
     /// On success, the returned source has completed an initial synchronization with
@@ -429,8 +462,8 @@ impl X509SourceBuilder {
     /// # Errors
     ///
     /// Returns an [`X509SourceError`] if the Workload API endpoint cannot be resolved
-    /// or connected to, the initial synchronization fails, or no suitable X.509 SVID
-    /// can be selected.
+    /// or connected to, the initial synchronization fails or times out, or no suitable
+    /// X.509 SVID can be selected.
     pub async fn build(self) -> Result<X509Source, X509SourceError> {
         let make_client = self.make_client.unwrap_or_else(|| {
             Arc::new(|| Box::pin(async { WorkloadApiClient::connect_env().await }))
@@ -443,6 +476,7 @@ impl X509SourceBuilder {
             self.limits,
             self.metrics,
             self.shutdown_timeout,
+            self.initial_sync_timeout,
         )
         .await
     }
@@ -491,6 +525,18 @@ mod tests {
         // Builder stores raw values; normalization happens later at the boundary
         assert_eq!(builder.reconnect.min_backoff, Duration::from_secs(10));
         assert_eq!(builder.reconnect.max_backoff, Duration::from_secs(1));
+    }
+
+    #[test]
+    fn initial_sync_timeout_defaults_to_none() {
+        let builder = X509SourceBuilder::new();
+        assert_eq!(builder.initial_sync_timeout, None);
+    }
+
+    #[test]
+    fn initial_sync_timeout_setter_stores_timeout() {
+        let builder = X509SourceBuilder::new().initial_sync_timeout(Duration::from_secs(5));
+        assert_eq!(builder.initial_sync_timeout, Some(Duration::from_secs(5)));
     }
 
     #[test]

--- a/spiffe/src/x509_source/errors.rs
+++ b/spiffe/src/x509_source/errors.rs
@@ -21,6 +21,14 @@ pub enum X509SourceError {
     #[error("source is closed")]
     Closed,
 
+    /// Initial synchronization timeout exceeded.
+    ///
+    /// This error occurs when `X509SourceBuilder::initial_sync_timeout()` is configured
+    /// and the initial synchronization performed during source construction does not
+    /// complete within the specified timeout.
+    #[error("initial synchronization timed out")]
+    InitialSyncTimeout,
+
     /// The workload API stream ended.
     ///
     /// This error occurs when the gRPC stream from the Workload API terminates

--- a/spiffe/src/x509_source/source.rs
+++ b/spiffe/src/x509_source/source.rs
@@ -11,6 +11,7 @@ use crate::x509_source::types::{ClientFactory, SvidPicker};
 use crate::{TrustDomain, X509Bundle, X509BundleSet, X509SourceBuilder, X509Svid};
 use arc_swap::ArcSwap;
 use std::fmt::Debug;
+use std::future::Future;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -105,9 +106,10 @@ impl X509SourceUpdates {
 
     /// Waits for the sequence number to satisfy a predicate.
     ///
-    /// This method first checks the current sequence number; if the predicate
-    /// is already satisfied, it returns immediately without waiting. Otherwise,
-    /// it repeatedly calls `changed()` until the predicate returns `true`.
+    /// This method first checks whether the source is closed, then checks the
+    /// current sequence number; if the predicate is already satisfied, it returns
+    /// immediately without waiting. Otherwise, it repeatedly calls `changed()`
+    /// until the predicate returns `true`.
     ///
     /// # Errors
     ///
@@ -116,6 +118,10 @@ impl X509SourceUpdates {
     where
         F: FnMut(&u64) -> bool,
     {
+        if self.shutdown.is_cancelled() {
+            return Err(X509SourceError::Closed);
+        }
+
         let current = self.last();
         if f(&current) {
             return Ok(current);
@@ -307,6 +313,14 @@ impl X509Source {
     /// `svid()`, the source may be shut down or the context may change. Use this
     /// for best-effort health checks (e.g., monitoring), not for synchronization.
     /// If you need a guaranteed check, call `svid()` directly and handle the error.
+    /// `build()` / builder `build()` only indicates that initial sync completed successfully;
+    /// `is_healthy()` is a runtime health signal, not a construction-success signal. There
+    /// may be a brief scheduler-dependent window immediately after construction where this
+    /// method returns `false` until the background supervisor task is first polled.
+    ///
+    /// If a [`MetricsRecorder`] or picker callback panics, the supervisor task terminates,
+    /// update handles close, and this method reports `false` afterward. Rebuild the source
+    /// to resume updates.
     ///
     /// # Examples
     ///
@@ -332,6 +346,9 @@ impl X509Source {
         }
 
         let Some(now) = unix_timestamp_now() else {
+            // If the wall clock is unavailable, health is reported conservatively as
+            // unhealthy. Validation is more optimistic to avoid rejecting otherwise
+            // usable initial sync data.
             return false;
         };
 
@@ -537,6 +554,7 @@ impl X509Source {
         limits: ResourceLimits,
         metrics: Option<Arc<dyn MetricsRecorder>>,
         shutdown_timeout: Option<Duration>,
+        initial_sync_timeout: Option<Duration>,
     ) -> Result<Self, X509SourceError> {
         let reconnect = super::builder::normalize_reconnect(reconnect);
 
@@ -544,15 +562,16 @@ impl X509Source {
         let cancel = CancellationToken::new();
         let shutdown_guard = Arc::new(cancel.clone().drop_guard());
 
-        let (initial_ctx, selected_svid) = initial_sync_with_retry(
+        let initial_sync = initial_sync_with_retry(
             &make_client,
             svid_picker.as_deref(),
             &cancel,
             reconnect,
             limits,
             metrics.as_deref(),
-        )
-        .await?;
+        );
+        let (initial_ctx, selected_svid) =
+            initial_sync_with_timeout(initial_sync, &cancel, initial_sync_timeout).await?;
         let snapshot = Arc::new(Snapshot {
             ctx: initial_ctx,
             expiry_unix: selected_svid.expiry_unix(),
@@ -576,10 +595,9 @@ impl X509Source {
 
         let task_inner = Arc::clone(&inner);
         let token = task_inner.cancel.clone();
-        let terminate_guard =
-            SupervisorTerminationGuard::new(Arc::clone(&task_inner), token.clone());
+        let guard_inner = Arc::clone(&task_inner);
         let handle = tokio::spawn(async move {
-            let _terminate_on_drop = terminate_guard;
+            let _terminate_on_drop = SupervisorTerminationGuard::new(guard_inner);
             task_inner.run_update_supervisor(token).await;
         });
 
@@ -651,13 +669,12 @@ impl X509Source {
 
 struct SupervisorTerminationGuard {
     inner: Arc<Inner>,
-    token: CancellationToken,
 }
 
 impl SupervisorTerminationGuard {
-    fn new(inner: Arc<Inner>, token: CancellationToken) -> Self {
+    fn new(inner: Arc<Inner>) -> Self {
         inner.supervisor_running.store(true, Ordering::Release);
-        Self { inner, token }
+        Self { inner }
     }
 }
 
@@ -666,7 +683,7 @@ impl Drop for SupervisorTerminationGuard {
         self.inner
             .supervisor_running
             .store(false, Ordering::Release);
-        self.token.cancel();
+        self.inner.cancel.cancel();
     }
 }
 
@@ -728,6 +745,27 @@ impl Inner {
     }
 }
 
+async fn initial_sync_with_timeout<T, F>(
+    initial_sync: F,
+    cancel: &CancellationToken,
+    timeout: Option<Duration>,
+) -> Result<T, X509SourceError>
+where
+    F: Future<Output = Result<T, X509SourceError>>,
+{
+    let Some(timeout) = timeout else {
+        return initial_sync.await;
+    };
+
+    match tokio::time::timeout(timeout, initial_sync).await {
+        Ok(result) => result,
+        Err(_elapsed) => {
+            cancel.cancel();
+            Err(X509SourceError::InitialSyncTimeout)
+        }
+    }
+}
+
 impl SvidSource for X509Source {
     type Item = X509Svid;
     type Error = X509SourceError;
@@ -772,9 +810,7 @@ mod tests {
     }
 
     fn supervisor_running_guard_for_test(source: &X509Source) -> SupervisorTerminationGuard {
-        let task_inner = Arc::clone(&source.inner);
-        let token = task_inner.cancel.clone();
-        SupervisorTerminationGuard::new(task_inner, token)
+        SupervisorTerminationGuard::new(Arc::clone(&source.inner))
     }
 
     async fn terminate_supervisor_for_test(terminate_guard: SupervisorTerminationGuard) {
@@ -783,6 +819,48 @@ mod tests {
         })
         .await
         .expect("supervisor termination task should not panic");
+    }
+
+    #[tokio::test]
+    async fn initial_sync_timeout_returns_timeout_and_cancels_token() {
+        let cancel = CancellationToken::new();
+
+        let result = initial_sync_with_timeout(
+            std::future::pending::<Result<(), X509SourceError>>(),
+            &cancel,
+            Some(Duration::ZERO),
+        )
+        .await;
+
+        assert!(matches!(result, Err(X509SourceError::InitialSyncTimeout)));
+        assert!(cancel.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn initial_sync_timeout_allows_success_before_timeout() {
+        let cancel = CancellationToken::new();
+
+        let result = initial_sync_with_timeout(
+            async { Ok::<_, X509SourceError>("synced") },
+            &cancel,
+            Some(Duration::from_secs(60)),
+        )
+        .await;
+
+        assert_eq!(result.unwrap(), "synced");
+        assert!(!cancel.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn initial_sync_without_timeout_waits_for_future() {
+        let cancel = CancellationToken::new();
+
+        let result =
+            initial_sync_with_timeout(async { Ok::<_, X509SourceError>("synced") }, &cancel, None)
+                .await;
+
+        assert_eq!(result.unwrap(), "synced");
+        assert!(!cancel.is_cancelled());
     }
 
     fn set_selected_svid_expiry_for_test(source: &X509Source, expiry_unix: i64) {
@@ -945,6 +1023,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn wait_for_returns_closed_after_shutdown_even_when_predicate_matches_current() {
+        let source = X509Source::new_for_test(
+            test_x509_context(),
+            ReconnectConfig::default(),
+            ResourceLimits::default(),
+            None,
+            None,
+        );
+        let mut updates = source.updated();
+        let current = updates.last();
+
+        source.shutdown().await;
+
+        let result = updates.wait_for(|seq| *seq == current).await;
+        assert!(matches!(result, Err(X509SourceError::Closed)));
+    }
+
+    #[tokio::test]
     async fn test_updates_changed_delivers_pending_update_before_closed() {
         let source = X509Source::new_for_test(
             test_x509_context(),
@@ -1053,6 +1149,26 @@ mod tests {
         assert!(matches!(waited, Err(X509SourceError::Closed)));
     }
 
+    #[tokio::test]
+    async fn wait_for_returns_closed_after_supervisor_termination_even_when_predicate_matches_current(
+    ) {
+        let source = X509Source::new_for_test(
+            test_x509_context(),
+            ReconnectConfig::default(),
+            ResourceLimits::default(),
+            None,
+            None,
+        );
+        let running_guard = supervisor_running_guard_for_test(&source);
+        let mut updates = source.updated();
+        let current = updates.last();
+
+        terminate_supervisor_for_test(running_guard).await;
+
+        let result = updates.wait_for(|seq| *seq == current).await;
+        assert!(matches!(result, Err(X509SourceError::Closed)));
+    }
+
     #[test]
     fn test_is_healthy_returns_false_when_selected_svid_is_expired() {
         let source = X509Source::new_for_test(
@@ -1075,6 +1191,38 @@ mod tests {
             !source.is_healthy(),
             "source should be unhealthy once selected SVID expiry is reached"
         );
+    }
+
+    #[tokio::test]
+    async fn is_healthy_false_after_shutdown() {
+        let source = X509Source::new_for_test(
+            test_x509_context(),
+            ReconnectConfig::default(),
+            ResourceLimits::default(),
+            None,
+            None,
+        );
+        let _running_guard = supervisor_running_guard_for_test(&source);
+
+        assert!(source.is_healthy());
+        source.shutdown().await;
+        assert!(!source.is_healthy());
+    }
+
+    #[test]
+    fn is_healthy_false_after_cancel() {
+        let source = X509Source::new_for_test(
+            test_x509_context(),
+            ReconnectConfig::default(),
+            ResourceLimits::default(),
+            None,
+            None,
+        );
+        let _running_guard = supervisor_running_guard_for_test(&source);
+
+        assert!(source.is_healthy());
+        source.inner.cancel.cancel();
+        assert!(!source.is_healthy());
     }
 
     /// Test metrics recorder that counts error recordings by kind.

--- a/spiffe/src/x509_source/types.rs
+++ b/spiffe/src/x509_source/types.rs
@@ -10,6 +10,8 @@ use std::sync::Arc;
 /// Implement this trait to customize SVID selection logic. The picker is called whenever
 /// a new X.509 context is received from the Workload API.
 /// Implementations must not panic.
+/// Implementations must be deterministic for a given slice of SVIDs, because the selected
+/// SVID expiry is cached per snapshot for health checks.
 ///
 /// # Example
 ///

--- a/spiffe/tests/jwt_source.rs
+++ b/spiffe/tests/jwt_source.rs
@@ -104,6 +104,19 @@ mod integration_tests_jwt_source {
         JwtSource::new().await.expect("Failed to create JwtSource")
     }
 
+    async fn wait_until_healthy(source: &JwtSource) {
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if source.is_healthy() {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("Source should become healthy after creation");
+    }
+
     #[tokio::test]
     #[ignore = "requires running SPIFFE Workload API"]
     async fn test_get_bundle_for_trust_domain() {
@@ -189,20 +202,15 @@ mod integration_tests_jwt_source {
     async fn test_is_healthy() {
         let source = get_source().await;
 
-        // Should be healthy when source is active
-        assert!(
-            source.is_healthy(),
-            "Source should be healthy after creation"
-        );
+        // build() waits for initial sync, but the supervisor may need one scheduler poll
+        // before is_healthy() reports runtime health.
+        wait_until_healthy(&source).await;
 
-        // If healthy, bundle_for_trust_domain() should succeed
-        if source.is_healthy() {
-            let bundle_result = source.bundle_for_trust_domain(&trust_domain());
-            assert!(
-                bundle_result.is_ok(),
-                "If is_healthy() returns true, bundle_for_trust_domain() should succeed"
-            );
-        }
+        let bundle_result = source.bundle_for_trust_domain(&trust_domain());
+        assert!(
+            bundle_result.is_ok(),
+            "If is_healthy() returns true, bundle_for_trust_domain() should succeed"
+        );
 
         // After shutdown, should be unhealthy
         source.shutdown().await;

--- a/spiffe/tests/x509_source.rs
+++ b/spiffe/tests/x509_source.rs
@@ -114,6 +114,19 @@ mod integration_tests_x509_source {
             .expect("Failed to create X509Source")
     }
 
+    async fn wait_until_healthy(source: &X509Source) {
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if source.is_healthy() {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("Source should become healthy after creation");
+    }
+
     #[tokio::test]
     #[ignore = "requires running SPIFFE Workload API"]
     async fn test_get_x509_svid() {
@@ -233,20 +246,15 @@ mod integration_tests_x509_source {
     async fn test_is_healthy() {
         let source = get_source().await;
 
-        // Should be healthy when source is active
-        assert!(
-            source.is_healthy(),
-            "Source should be healthy after creation"
-        );
+        // build() waits for initial sync, but the supervisor may need one scheduler poll
+        // before is_healthy() reports runtime health.
+        wait_until_healthy(&source).await;
 
-        // If healthy, svid() should succeed
-        if source.is_healthy() {
-            let svid_result = source.svid();
-            assert!(
-                svid_result.is_ok(),
-                "If is_healthy() returns true, svid() should succeed"
-            );
-        }
+        let svid_result = source.svid();
+        assert!(
+            svid_result.is_ok(),
+            "If is_healthy() returns true, svid() should succeed"
+        );
 
         // After shutdown, should be unhealthy
         source.shutdown().await;


### PR DESCRIPTION
## Context
Hardens the X.509 and JWT source lifecycle behavior around initial synchronization, supervisor termination, update waiters, and health reporting.

## Changes
- Add configurable initial sync timeout handling for X.509 and JWT sources.
- Remove eager JWT on-demand client creation during construction; create it lazily on first JWT SVID fetch.
- Move supervisor running-state guard creation into the spawned supervisor task.
- Make update `wait_for()` return `Closed` before evaluating predicates after shutdown or supervisor termination.
- Tighten `is_healthy()` behavior and documentation for shutdown, cancellation, supervisor termination, and post-build scheduling windows.
- Add focused unit coverage for timeout, lazy JWT client creation, health branches, and closed update waiter behavior.

## Security
- Advisory: none
- Fix: source construction and health/update signals now fail closed more consistently during timeout, shutdown, cancellation, and supervisor termination paths.

## Compatibility
- MSRV: unchanged
- Breaking changes: none
- Affected crates/features: `spiffe` with `x509-source` and/or `jwt-source`

## Testing
- `cargo test -p spiffe --features jwt-source jwt_source::source::tests`
- `cargo test -p spiffe --features x509-source x509_source::source::tests`
- `cargo test -p spiffe --features x509-source,jwt-source --lib`
- `cargo test -p spiffe --features x509-source,jwt-source`
- `cargo clippy -p spiffe --features jwt-source -- -D warnings`
- `git diff --check`

## Release notes
- `spiffe`: harden X.509/JWT source construction, health, shutdown, and update waiter behavior.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxlambrecht/rust-spiffe/337)
<!-- Reviewable:end -->
