### PR TITLE
feat(spiffe)!: mark X509SourceError and JwtSourceError as non_exhaustive 

### DIFF
--- a/spiffe/src/jwt_source/errors.rs
+++ b/spiffe/src/jwt_source/errors.rs
@@ -4,6 +4,7 @@ use thiserror::Error;
 
 /// Errors returned by `JwtSource`.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum JwtSourceError {
     /// Failed to retrieve or refresh JWT material from the source.
     #[error("jwt source error: {0}")]

--- a/spiffe/src/x509_source/errors.rs
+++ b/spiffe/src/x509_source/errors.rs
@@ -4,6 +4,7 @@ use thiserror::Error;
 
 /// Errors returned by `X509Source`.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum X509SourceError {
     /// Failed to retrieve or refresh X.509 material from the source.
     #[error("x509 source error: {0}")]


### PR DESCRIPTION
## Context

`X509SourceError` and `JwtSourceError` have gained new variants in nearly every
release. Without `#[non_exhaustive]`, every addition is a semver-major break
requiring a major version bump. This change opts the enums into the standard
Rust convention for evolving library error types.

## Changes

- Added `#[non_exhaustive]` to `X509SourceError` in `spiffe/src/x509_source/errors.rs`
- Added `#[non_exhaustive]` to `JwtSourceError` in `spiffe/src/jwt_source/errors.rs`

No logic changes. Internal exhaustive matches within the crate are unaffected
(verified by `cargo check`).

## Security

- Advisory: none
- Fix: n/a

## Compatibility

- MSRV: unchanged
- Breaking changes: callers with exhaustive `match` arms on `X509SourceError`
  or `JwtSourceError` must add a wildcard `_ =>` arm
- Affected crates/features: `spiffe` — `x509-source`, `jwt-source` features

## Testing

Covered by CI. No behaviour changes; existing unit and integration tests pass
unchanged.

## Release notes

`X509SourceError` and `JwtSourceError` are now `#[non_exhaustive]`. Exhaustive
`match` arms must add a wildcard `_ =>` arm. Future variants will no longer
require a major version bump.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxlambrecht/rust-spiffe/338)
<!-- Reviewable:end -->
