### PR TITLE
chore: prepare spiffe 0.14 dependent crate releases

### DIFF
--- a/spiffe-rustls-tokio/CHANGELOG.md
+++ b/spiffe-rustls-tokio/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.2.0] – 2026-04-25
+
+### Breaking changes
+
+- Bump the `spiffe` dependency from 0.13 to 0.14. `spiffe-rustls-tokio` exposes `spiffe::SpiffeId` through `PeerIdentity`, so downstream users must use compatible `spiffe` 0.14 types.
+- Update examples and development dependency to `spiffe-rustls` 0.5.
+
 ## [0.1.4] – 2026-04-18
 
 ### Changed

--- a/spiffe-rustls-tokio/Cargo.toml
+++ b/spiffe-rustls-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spiffe-rustls-tokio"
-version = "0.1.4"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -28,7 +28,7 @@ thiserror = "2"
 [dev-dependencies]
 anyhow = "1"
 env_logger = "0.11"
-spiffe-rustls = { version = "0.4.9", path = "../spiffe-rustls" }
+spiffe-rustls = { version = "0.5", path = "../spiffe-rustls" }
 tokio = { version = "1", default-features = false, features = [
     "rt-multi-thread",
     "signal",

--- a/spiffe-rustls-tokio/README.md
+++ b/spiffe-rustls-tokio/README.md
@@ -19,9 +19,9 @@ Add `spiffe-rustls-tokio` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spiffe-rustls-tokio = "0.1"
-spiffe-rustls = "0.4"
-spiffe = { version = "0.13", features = ["x509-source"] }
+spiffe-rustls-tokio = "0.2"
+spiffe-rustls = "0.5"
+spiffe = { version = "0.14", features = ["x509-source"] }
 ```
 
 ---

--- a/spiffe-rustls/CHANGELOG.md
+++ b/spiffe-rustls/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.5.0] – 2026-04-25
+
+### Breaking changes
+
+- Bumped the `spiffe` dependency from `0.13` to `0.14`. Because
+  `spiffe-rustls` exposes `spiffe` types in its public API, downstream users
+  must use compatible `spiffe` `0.14` types.
+
+### Changed
+
+- Updated `spiffe-rustls` to use the latest `spiffe` source lifecycle,
+  health-check, and initial-sync timeout behavior.
+
 ## [0.4.9] – 2026-04-18
 
 ### Changed

--- a/spiffe-rustls/Cargo.toml
+++ b/spiffe-rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spiffe-rustls"
-version = "0.4.9"
+version = "0.5.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/spiffe/README.md
+++ b/spiffe/README.md
@@ -20,16 +20,16 @@ Add `spiffe` to your `Cargo.toml`. All features are opt-in:
 ```toml
 [dependencies]
 # Minimal: only SPIFFE primitives 
-spiffe = "0.13"
+spiffe = "0.14"
 
 # OR X.509 workloads (recommended)
-# spiffe = { version = "0.13", features = ["x509-source"] }
+# spiffe = { version = "0.14", features = ["x509-source"] }
 
 # OR JWT workloads (recommended)
-# spiffe = { version = "0.13", features = ["jwt-source"] }
+# spiffe = { version = "0.14", features = ["jwt-source"] }
 
 # OR Direct Workload API usage
-# spiffe = { version = "0.13", features = ["workload-api"] }
+# spiffe = { version = "0.14", features = ["workload-api"] }
 ```
 
 ---
@@ -275,14 +275,14 @@ backend.
 
 ```toml
 [dependencies]
-spiffe = { version = "0.13", features = ["jwt-verify-rust-crypto"] }
+spiffe = { version = "0.14", features = ["jwt-verify-rust-crypto"] }
 ```
 
 #### Using the AWS-LC backend
 
 ```toml
 [dependencies]
-spiffe = { version = "0.13", features = ["jwt-verify-aws-lc-rs"] }
+spiffe = { version = "0.14", features = ["jwt-verify-aws-lc-rs"] }
 ```
 
 This enables local signature verification using JWT authorities from bundles:
@@ -436,7 +436,7 @@ facade. Events are emitted via `log::debug!`, `log::info!`, `log::warn!`, and `l
 
 ```toml
 [dependencies]
-spiffe = { version = "0.13", features = ["logging"] }
+spiffe = { version = "0.14", features = ["logging"] }
 ```
 
 **Note:** The `logging` feature is not included in the default `workload-api` feature.
@@ -452,7 +452,7 @@ or distributed tracing systems. When both `tracing` and `logging` features are e
 
 ```toml
 [dependencies]
-spiffe = { version = "0.13", features = ["tracing"] }
+spiffe = { version = "0.14", features = ["tracing"] }
 ```
 
 **Note:** The `tracing` and `logging` features are not mutually exclusive. When both
@@ -468,7 +468,7 @@ In addition to the higher-level bundles (`workload-api-x509`, `workload-api-jwt`
 
 ```toml
 [dependencies]
-spiffe = { version = "0.13", features = ["workload-api-core"] }
+spiffe = { version = "0.14", features = ["workload-api-core"] }
 ```
 
 This feature includes:

--- a/spire-api/CHANGELOG.md
+++ b/spire-api/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.6.0] – 2026-04-25
+
+### Breaking changes
+
+- Bump the `spiffe` dependency from 0.13 to 0.14. `spire-api` exposes `spiffe` types in its public API, so downstream users must use compatible `spiffe` 0.14 types.
+
 ## [0.5.5] – 2026-04-18
 
 ### Changed

--- a/spire-api/Cargo.toml
+++ b/spire-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spire-api"
-version = "0.5.5"
+version = "0.6.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/spire-api/README.md
+++ b/spire-api/README.md
@@ -32,7 +32,7 @@ Add `spire-api` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spire-api = "0.5"
+spire-api = "0.6"
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Bump `spiffe-rustls` to `0.5.0` because it exposes `spiffe` types and now depends on `spiffe 0.14`.
- Bump `spire-api` to `0.6.0` because it exposes `spiffe` types and now depends on `spiffe 0.14`.
- Bump `spiffe-rustls-tokio` to `0.2.0` because `PeerIdentity` exposes `spiffe::SpiffeId` and it now depends on `spiffe 0.14`.
- Update changelogs and README install snippets for the new release versions.


## Release order

After merge, publish tags in dependency order:

1. `spire-api-0.6.0`
2. `spiffe-rustls-0.5.0`
3. `spiffe-rustls-tokio-0.2.0`

`spiffe-0.14.0` is already published.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxlambrecht/rust-spiffe/340)
<!-- Reviewable:end -->
