### PR TITLE
docs(spiffe-rustls): clarify default posture and config customizer risks

### DIFF
--- a/spiffe-rustls/README.md
+++ b/spiffe-rustls/README.md
@@ -44,6 +44,9 @@ let client_cfg = mtls_client(source)
 The resulting `ClientConfig` can be used directly with `rustls`, or integrated into
 [`spiffe-rustls-tokio`](https://crates.io/crates/spiffe-rustls-tokio), `tokio-rustls`, `tonic-rustls`, or similar libraries.
 
+For non-federated deployments, also configure `TrustDomainPolicy::LocalOnly(...)`.
+See “Trust Domain Policy” below for details.
+
 ---
 
 ## Federation
@@ -80,6 +83,10 @@ using `TrustDomainPolicy`.
 This is a **defense-in-depth** mechanism. The primary trust model comes from the bundle set
 delivered by the Workload API.
 
+By default, `spiffe-rustls` uses `TrustDomainPolicy::AnyInBundleSet`. This accepts any
+trust domain present in the source bundle set. For non-federated deployments, configure
+`TrustDomainPolicy::LocalOnly(...)` to restrict verification to the local trust domain.
+
 ```rust
 use spiffe_rustls::TrustDomainPolicy;
 
@@ -107,6 +114,12 @@ Authorization is applied **after** cryptographic verification succeeds.
 
 The crate provides a strongly-typed `Authorizer` trait and constructors for
 common authorization strategies.
+
+The default authorizer is `authorizer::any()`. It accepts any authenticated SPIFFE ID
+from any trust domain accepted by the configured trust-domain policy. By default, this
+means every trust domain in the source bundle set. Production deployments should usually
+configure a more specific authorizer, such as an exact SPIFFE ID allow-list or a
+trust-domain allow-list.
 
 ### Common authorization patterns
 
@@ -234,7 +247,7 @@ Common protocols:
 
 For configuration not directly exposed by the builder, use `with_config_customizer`.
 The customizer runs **last**, after all other builder settings (including ALPN)
-have been applied, allowing you to override any configuration:
+have been applied, and gives direct access to the underlying rustls configuration:
 
 ```rust
 use spiffe_rustls::mtls_server;
@@ -249,9 +262,8 @@ let config = mtls_server(source)
     .build()?;
 ```
 
-**Warning:** Do not modify or replace the verifier or certificate resolver, as they
-are required for SPIFFE authentication and authorization. Safe to modify: ALPN, cipher
-suites, protocol versions, and other non-security-critical settings.
+**Warning:** Replacing the verifier or resolver disables SPIFFE authentication. Do not
+use this hook for that purpose; build a custom rustls configuration instead.
 
 ---
 
@@ -376,7 +388,8 @@ Authorization is applied **after** TLS verification succeeds, ensuring cryptogra
 
 * Certificates must contain **exactly one** SPIFFE ID URI SAN
 * Trust bundles are sourced exclusively from the Workload API
-* Trust domain selection is automatic and deterministic
+* The default trust-domain policy accepts any trust domain present in the source bundle set
+* The default authorizer accepts any authenticated SPIFFE ID from any trust domain accepted by the configured trust-domain policy. By default, this means every trust domain in the source bundle set.
 * Authorization runs **after** cryptographic verification
 * Material updates are atomic; new handshakes use fresh material
 

--- a/spiffe-rustls/src/authorizer.rs
+++ b/spiffe-rustls/src/authorizer.rs
@@ -37,7 +37,14 @@ impl Authorizer for Box<dyn Authorizer> {
     }
 }
 
-/// Authorizes any SPIFFE ID (authentication only, no authorization).
+/// Authorizes any authenticated SPIFFE ID under the active trust-domain policy.
+///
+/// By default (`TrustDomainPolicy::AnyInBundleSet`), every trust domain in the source
+/// bundle set is accepted.
+///
+/// This is the default authorizer for client and server builders. Production
+/// deployments should usually configure a more specific authorizer, such as
+/// [`exact`] or [`trust_domains`].
 #[must_use]
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Any;
@@ -138,11 +145,18 @@ impl Authorizer for TrustDomainAllowList {
     }
 }
 
-/// Returns an authorizer that accepts any SPIFFE ID.
+/// Returns an authorizer that accepts any authenticated SPIFFE ID.
+///
+/// The peer's trust domain must be accepted by the configured trust-domain policy.
+/// By default (`TrustDomainPolicy::AnyInBundleSet`), every trust domain in the source
+/// bundle set is accepted.
 ///
 /// This is useful when authorization is performed at another layer
 /// (e.g., application-level RBAC). Authentication (certificate verification)
 /// still applies.
+///
+/// This is the default authorizer for client and server builders. Production
+/// deployments should usually configure a more specific authorizer.
 ///
 /// Returns a zero-sized `Any` value that can be used directly.
 ///

--- a/spiffe-rustls/src/client.rs
+++ b/spiffe-rustls/src/client.rs
@@ -31,12 +31,20 @@ type ClientConfigCustomizer = Box<dyn FnOnce(&mut ClientConfig) + Send>;
 /// manual configuration is required. You can optionally restrict which trust
 /// domains are accepted using [`Self::trust_domain_policy`].
 ///
+/// The default policy is [`TrustDomainPolicy::AnyInBundleSet`], which accepts any
+/// trust domain present in the source bundle set. For non-federated deployments,
+/// prefer [`TrustDomainPolicy::LocalOnly`] to restrict verification to the local
+/// trust domain.
+///
 /// ## Authorization
 ///
 /// Server authorization is performed by invoking the provided [`Authorizer`] with
 /// the server's SPIFFE ID extracted from the certificate's URI SAN.
 ///
-/// Use [`authorizer::any`] to disable authorization while retaining full TLS authentication.
+/// The default authorizer is [`crate::authorizer::any`]. It accepts any authenticated
+/// SPIFFE ID from any trust domain accepted by the configured trust-domain policy.
+/// By default, this means every trust domain in the source bundle set. Production
+/// deployments should usually configure a more specific authorizer.
 ///
 /// # Examples
 ///
@@ -87,9 +95,15 @@ impl ClientConfigBuilder {
     /// Creates a new builder from an `X509Source`.
     ///
     /// Defaults:
-    /// - Authorization: accepts any SPIFFE ID (authentication only)
-    /// - Trust domain policy: `AnyInBundleSet` (uses all bundles from the Workload API)
+    /// - Authorization: [`crate::authorizer::any`], which accepts any authenticated
+    ///   SPIFFE ID from any trust domain accepted by the configured trust-domain policy.
+    ///   By default, this means every trust domain in the source bundle set.
+    /// - Trust domain policy: [`TrustDomainPolicy::AnyInBundleSet`], which accepts any
+    ///   trust domain present in the source bundle set
     /// - ALPN protocols: empty (no ALPN)
+    ///
+    /// Production deployments should usually configure a more specific authorizer.
+    /// Non-federated deployments should usually configure [`TrustDomainPolicy::LocalOnly`].
     pub fn new(source: X509Source) -> Self {
         Self {
             source: Arc::new(source),
@@ -140,7 +154,10 @@ impl ClientConfigBuilder {
 
     /// Sets the trust domain policy.
     ///
-    /// Defaults to `AnyInBundleSet` (uses all bundles from the Workload API).
+    /// Defaults to [`TrustDomainPolicy::AnyInBundleSet`], which accepts any trust
+    /// domain present in the source bundle set. For non-federated deployments,
+    /// prefer [`TrustDomainPolicy::LocalOnly`] to restrict verification to the local
+    /// trust domain.
     #[must_use]
     pub fn trust_domain_policy(mut self, policy: TrustDomainPolicy) -> Self {
         self.trust_domain_policy = policy;
@@ -182,11 +199,11 @@ impl ClientConfigBuilder {
     ///
     /// This is an **advanced** API for configuration not directly exposed by the builder.
     /// The customizer is called **last**, after all other builder settings (including
-    /// ALPN) have been applied, allowing you to override any configuration.
+    /// ALPN) have been applied, and gives direct access to the underlying `rustls`
+    /// configuration.
     ///
-    /// **Warning:** Do not modify or replace the verifier or client certificate resolver,
-    /// as they are required for SPIFFE authentication and authorization. Safe to modify:
-    /// ALPN, cipher suites, protocol versions, and other non-security-critical settings.
+    /// **Warning:** Replacing the verifier or resolver disables SPIFFE authentication.
+    /// Do not use this hook for that purpose; build a custom `rustls` configuration instead.
     ///
     /// # Examples
     ///

--- a/spiffe-rustls/src/lib.rs
+++ b/spiffe-rustls/src/lib.rs
@@ -16,6 +16,12 @@
 //! trust domain bundle based on the peer's SPIFFE ID. Authorization is applied **after**
 //! cryptographic verification succeeds.
 //!
+//! By default, builders use [`TrustDomainPolicy::AnyInBundleSet`] and
+//! [`authorizer::any`]. This accepts any authenticated SPIFFE ID from any trust domain
+//! present in the source bundle set. For non-federated deployments, use
+//! [`TrustDomainPolicy::LocalOnly`]; for production deployments, configure an
+//! authorizer that matches the peer identities your application expects.
+//!
 //! For outbound TLS, peer identity is the SPIFFE ID in the URI SAN, not the TLS server name.
 //! Connecting to `localhost` or an IP is supported even when the X.509-SVID has no matching DNS SAN.
 //!
@@ -63,7 +69,16 @@ pub use spiffe::{SpiffeId, TrustDomain};
 
 /// Constructor for the mTLS client builder.
 ///
-/// Creates a client builder with default settings (accepts any SPIFFE ID, uses all bundles from the Workload API).
+/// Creates a client builder with default settings:
+///
+/// * authorizer: [`authorizer::any`], which accepts any authenticated SPIFFE ID
+///   from any trust domain accepted by the configured trust-domain policy. By default,
+///   this means every trust domain in the source bundle set.
+/// * trust-domain policy: [`TrustDomainPolicy::AnyInBundleSet`], which accepts any
+///   trust domain present in the source bundle set
+///
+/// Production deployments should usually configure a more specific authorizer. Non-federated
+/// deployments should usually configure [`TrustDomainPolicy::LocalOnly`].
 ///
 /// # Examples
 ///
@@ -87,7 +102,16 @@ pub fn mtls_client(source: spiffe::X509Source) -> ClientConfigBuilder {
 
 /// Constructor for the mTLS server builder.
 ///
-/// Creates a server builder with default settings (accepts any SPIFFE ID, uses all bundles from the Workload API).
+/// Creates a server builder with default settings:
+///
+/// * authorizer: [`authorizer::any`], which accepts any authenticated SPIFFE ID
+///   from any trust domain accepted by the configured trust-domain policy. By default,
+///   this means every trust domain in the source bundle set.
+/// * trust-domain policy: [`TrustDomainPolicy::AnyInBundleSet`], which accepts any
+///   trust domain present in the source bundle set
+///
+/// Production deployments should usually configure a more specific authorizer. Non-federated
+/// deployments should usually configure [`TrustDomainPolicy::LocalOnly`].
 ///
 /// # Examples
 ///

--- a/spiffe-rustls/src/policy.rs
+++ b/spiffe-rustls/src/policy.rs
@@ -3,6 +3,11 @@
 //! Provides [`TrustDomainPolicy`], which allows you to restrict which
 //! trust domains from the bundle set are actually used during certificate verification.
 //!
+//! The default policy is [`TrustDomainPolicy::AnyInBundleSet`], which accepts any
+//! trust domain present in the source bundle set. For non-federated deployments,
+//! prefer [`TrustDomainPolicy::LocalOnly`] to restrict verification to the local
+//! trust domain.
+//!
 //! # Examples
 //!
 //! ```rust
@@ -39,6 +44,8 @@ use std::collections::BTreeSet;
 /// additional layer of control over which trust domains are accepted.
 ///
 /// **Default**: `AnyInBundleSet` - use all bundles provided by the Workload API.
+/// This accepts any trust domain present in the source bundle set. For non-federated
+/// deployments, prefer `LocalOnly(...)`.
 ///
 /// # Examples
 ///
@@ -66,6 +73,9 @@ pub enum TrustDomainPolicy {
     /// the verifier to automatically select the correct bundle based on the
     /// peer's SPIFFE ID. No additional configuration is needed for federation
     /// to work.
+    ///
+    /// For non-federated deployments, prefer [`TrustDomainPolicy::LocalOnly`] to
+    /// restrict verification to the local trust domain.
     #[default]
     AnyInBundleSet,
 

--- a/spiffe-rustls/src/server.rs
+++ b/spiffe-rustls/src/server.rs
@@ -27,12 +27,20 @@ type ServerConfigCustomizer = Box<dyn FnOnce(&mut ServerConfig) + Send>;
 /// manual configuration is required. You can optionally restrict which trust
 /// domains are accepted using [`Self::trust_domain_policy`].
 ///
+/// The default policy is [`TrustDomainPolicy::AnyInBundleSet`], which accepts any
+/// trust domain present in the source bundle set. For non-federated deployments,
+/// prefer [`TrustDomainPolicy::LocalOnly`] to restrict verification to the local
+/// trust domain.
+///
 /// ## Authorization
 ///
 /// Client authorization is performed by invoking the provided [`Authorizer`] with
 /// the client's SPIFFE ID extracted from the certificate's URI SAN.
 ///
-/// Use [`authorizer::any`] to disable authorization while retaining full TLS authentication.
+/// The default authorizer is [`crate::authorizer::any`]. It accepts any authenticated
+/// SPIFFE ID from any trust domain accepted by the configured trust-domain policy.
+/// By default, this means every trust domain in the source bundle set. Production
+/// deployments should usually configure a more specific authorizer.
 ///
 /// # Examples
 ///
@@ -79,9 +87,15 @@ impl ServerConfigBuilder {
     /// Creates a new builder from an `X509Source`.
     ///
     /// Defaults:
-    /// - Authorization: accepts any SPIFFE ID (authentication only)
-    /// - Trust domain policy: `AnyInBundleSet` (uses all bundles from the Workload API)
+    /// - Authorization: [`crate::authorizer::any`], which accepts any authenticated
+    ///   SPIFFE ID from any trust domain accepted by the configured trust-domain policy.
+    ///   By default, this means every trust domain in the source bundle set.
+    /// - Trust domain policy: [`TrustDomainPolicy::AnyInBundleSet`], which accepts any
+    ///   trust domain present in the source bundle set
     /// - ALPN protocols: empty (no ALPN)
+    ///
+    /// Production deployments should usually configure a more specific authorizer.
+    /// Non-federated deployments should usually configure [`TrustDomainPolicy::LocalOnly`].
     pub fn new(source: X509Source) -> Self {
         Self {
             source: Arc::new(source),
@@ -131,7 +145,10 @@ impl ServerConfigBuilder {
 
     /// Sets the trust domain policy.
     ///
-    /// Defaults to `AnyInBundleSet` (uses all bundles from the Workload API).
+    /// Defaults to [`TrustDomainPolicy::AnyInBundleSet`], which accepts any trust
+    /// domain present in the source bundle set. For non-federated deployments,
+    /// prefer [`TrustDomainPolicy::LocalOnly`] to restrict verification to the local
+    /// trust domain.
     #[must_use]
     pub fn trust_domain_policy(mut self, policy: TrustDomainPolicy) -> Self {
         self.trust_domain_policy = policy;
@@ -173,11 +190,11 @@ impl ServerConfigBuilder {
     ///
     /// This is an **advanced** API for configuration not directly exposed by the builder.
     /// The customizer is called **last**, after all other builder settings (including
-    /// ALPN) have been applied, allowing you to override any configuration.
+    /// ALPN) have been applied, and gives direct access to the underlying `rustls`
+    /// configuration.
     ///
-    /// **Warning:** Do not modify or replace the verifier or server certificate resolver,
-    /// as they are required for SPIFFE authentication and authorization. Safe to modify:
-    /// ALPN, cipher suites, protocol versions, and other non-security-critical settings.
+    /// **Warning:** Replacing the verifier or resolver disables SPIFFE authentication.
+    /// Do not use this hook for that purpose; build a custom `rustls` configuration instead.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
## Context
Focused on documentation / security: make default trust-domain policy vs `authorizer::any()` explicit, avoid wording that sounds like a curated allow-list, add a Quick Start pointer to `LocalOnly`, and make `with_config_customizer` guidance directive.

## Changes
- README: default authorizer wording tied to `TrustDomainPolicy`; Quick Start note for `TrustDomainPolicy::LocalOnly(...)`; stronger `with_config_customizer` warning; Security Considerations bullets aligned with defaults.
- Crate and builder rustdocs (`lib.rs`, `client.rs`, `server.rs`, `authorizer.rs`): same default-authorizer wording; builder `with_config_customizer` warning aligned with README.

## Security
- Fix: Documentation only; no change to TLS verification, authorization behavior, or public API semantics.

## Compatibility
- MSRV: unchanged (workspace remains 1.88+ as documented for this crate).
- Breaking changes: none.
- Affected crates/features (if applicable): `spiffe-rustls` documentation and changelog text only.

## Testing
`cargo doc -p spiffe-rustls --no-deps` (local). No runtime or test changes.

## Release notes
### Docs

- Clarified the default security posture of `spiffe-rustls`, including the interaction between `TrustDomainPolicy::AnyInBundleSet` and `authorizer::any()`.
- Added stronger guidance to use `TrustDomainPolicy::LocalOnly(...)` and an explicit authorizer for non-federated production deployments.
- Strengthened the warning around `with_config_customizer`, which can bypass SPIFFE verification if the verifier or resolver is replaced.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxlambrecht/rust-spiffe/341)
<!-- Reviewable:end -->
