### PR TITLE
feat(spiffe): add InterceptorFn for per-RPC metadata injection on WorkloadApiClient

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
           components: cargo
 
       - name: Install cargo-audit
-        uses: taiki-e/install-action@cf525cb33f51aca27cd6fa02034117ab963ff9f1
+        uses: taiki-e/install-action@b5fddbb5361bce8a06fb168c9d403a6cc552b084
         with:
           tool: cargo-audit
 
@@ -206,7 +206,7 @@ jobs:
           components: cargo
 
       - name: Install cargo-deny
-        uses: taiki-e/install-action@cf525cb33f51aca27cd6fa02034117ab963ff9f1
+        uses: taiki-e/install-action@b5fddbb5361bce8a06fb168c9d403a6cc552b084
         with:
           tool: cargo-deny
 

--- a/spiffe/src/lib.rs
+++ b/spiffe/src/lib.rs
@@ -214,7 +214,7 @@ pub use crate::workload_api::X509Context;
     feature = "workload-api-jwt",
     feature = "workload-api-full"
 ))]
-pub use crate::workload_api::{WorkloadApiClient, WorkloadApiError};
+pub use crate::workload_api::{InterceptorFn, WorkloadApiClient, WorkloadApiError};
 
 // X.509 Source
 //

--- a/spiffe/src/workload_api/client/header.rs
+++ b/spiffe/src/workload_api/client/header.rs
@@ -41,16 +41,15 @@ impl tonic::service::Interceptor for MetadataAdder {
         &mut self,
         mut request: tonic::Request<()>,
     ) -> Result<tonic::Request<()>, tonic::Status> {
-        // Cloning is required: tonic's metadata insert() takes owned values.
-        // The LazyLock ensures these are only parsed once at initialization.
-        request
-            .metadata_mut()
-            .insert(PARSED_HEADER_KEY.clone(), PARSED_HEADER_VALUE.clone());
-
-        // Apply custom per-RPC metadata if provided.
+        // Apply custom per-RPC metadata first, so the required SPIFFE header
+        // cannot be accidentally removed or overwritten by a custom interceptor.
         if let Some(extra) = &self.extra {
             extra(&mut request)?;
         }
+
+        request
+            .metadata_mut()
+            .insert(PARSED_HEADER_KEY.clone(), PARSED_HEADER_VALUE.clone());
 
         Ok(request)
     }
@@ -96,6 +95,28 @@ mod tests {
         assert_eq!(
             response.metadata().get("authorization").expect("present"),
             "Bearer test-token",
+        );
+    }
+
+    #[test]
+    fn spiffe_header_preserved_when_custom_interceptor_overwrites_it() {
+        let interceptor: InterceptorFn = Arc::new(|req| {
+            req.metadata_mut().remove(SPIFFE_HEADER_KEY);
+            req.metadata_mut().insert(
+                MetadataKey::from_static(SPIFFE_HEADER_KEY),
+                MetadataValue::from_static("false"),
+            );
+            Ok(())
+        });
+
+        let mut adder = MetadataAdder::new(Some(interceptor));
+        let response = adder
+            .call(tonic::Request::new(()))
+            .expect("interceptor should succeed");
+
+        assert_eq!(
+            response.metadata().get(SPIFFE_HEADER_KEY).expect("present"),
+            SPIFFE_HEADER_VALUE,
         );
     }
 

--- a/spiffe/src/workload_api/client/header.rs
+++ b/spiffe/src/workload_api/client/header.rs
@@ -55,3 +55,60 @@ impl tonic::service::Interceptor for MetadataAdder {
         Ok(request)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tonic::service::Interceptor as _;
+
+    #[test]
+    fn spiffe_header_always_inserted() {
+        let mut adder = MetadataAdder::new(None);
+        let request = tonic::Request::new(());
+        let result = adder.call(request);
+
+        let response = result.expect("interceptor should succeed");
+        let value = response
+            .metadata()
+            .get(SPIFFE_HEADER_KEY)
+            .expect("spiffe header should be present");
+        assert_eq!(value, SPIFFE_HEADER_VALUE);
+    }
+
+    #[test]
+    fn custom_interceptor_metadata_added() {
+        let interceptor: InterceptorFn = Arc::new(|req| {
+            req.metadata_mut().insert(
+                MetadataKey::from_static("authorization"),
+                MetadataValue::from_static("Bearer test-token"),
+            );
+            Ok(())
+        });
+        let mut adder = MetadataAdder::new(Some(interceptor));
+        let request = tonic::Request::new(());
+        let result = adder.call(request);
+
+        let response = result.expect("interceptor should succeed");
+        assert_eq!(
+            response.metadata().get(SPIFFE_HEADER_KEY).expect("present"),
+            SPIFFE_HEADER_VALUE,
+        );
+        assert_eq!(
+            response.metadata().get("authorization").expect("present"),
+            "Bearer test-token",
+        );
+    }
+
+    #[test]
+    fn custom_interceptor_error_propagates() {
+        let interceptor: InterceptorFn =
+            Arc::new(|_| Err(tonic::Status::internal("token expired")));
+        let mut adder = MetadataAdder::new(Some(interceptor));
+        let request = tonic::Request::new(());
+        let result = adder.call(request);
+
+        let err = result.expect_err("interceptor should fail");
+        assert_eq!(err.code(), tonic::Code::Internal);
+        assert_eq!(err.message(), "token expired");
+    }
+}

--- a/spiffe/src/workload_api/client/header.rs
+++ b/spiffe/src/workload_api/client/header.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use tonic::metadata::{Ascii, MetadataKey, MetadataValue};
 
 const SPIFFE_HEADER_KEY: &str = "workload.spiffe.io";
@@ -11,9 +13,28 @@ static PARSED_HEADER_KEY: std::sync::LazyLock<MetadataKey<Ascii>> =
 static PARSED_HEADER_VALUE: std::sync::LazyLock<MetadataValue<Ascii>> =
     std::sync::LazyLock::new(|| MetadataValue::from_static(SPIFFE_HEADER_VALUE));
 
-/// Tonic interceptor that adds the Workload API metadata header required by SPIRE.
+/// Per-RPC metadata interceptor function type.
+///
+/// Called on every gRPC request to inject custom metadata (e.g. K8s SA
+/// tokens for identity-server authentication).
+pub type InterceptorFn =
+    Arc<dyn Fn(&mut tonic::Request<()>) -> Result<(), tonic::Status> + Send + Sync>;
+
+/// Tonic interceptor that adds the Workload API metadata header required
+/// by SPIRE, plus optional custom per-RPC metadata.
+///
+/// The `extra` field supports identity-server's transport model where
+/// callers must provide authentication tokens on every RPC.
 #[derive(Clone)]
-pub(super) struct MetadataAdder;
+pub(super) struct MetadataAdder {
+    extra: Option<InterceptorFn>,
+}
+
+impl MetadataAdder {
+    pub(super) fn new(extra: Option<InterceptorFn>) -> Self {
+        Self { extra }
+    }
+}
 
 impl tonic::service::Interceptor for MetadataAdder {
     fn call(
@@ -25,6 +46,12 @@ impl tonic::service::Interceptor for MetadataAdder {
         request
             .metadata_mut()
             .insert(PARSED_HEADER_KEY.clone(), PARSED_HEADER_VALUE.clone());
+
+        // Apply custom per-RPC metadata if provided.
+        if let Some(extra) = &self.extra {
+            extra(&mut request)?;
+        }
+
         Ok(request)
     }
 }

--- a/spiffe/src/workload_api/client/mod.rs
+++ b/spiffe/src/workload_api/client/mod.rs
@@ -21,6 +21,8 @@ use crate::workload_api::client::header::MetadataAdder;
 use crate::workload_api::error::WorkloadApiError;
 use crate::workload_api::pb::workload::spiffe_workload_api_client::SpiffeWorkloadApiClient;
 
+pub use header::InterceptorFn;
+
 /// Client for the SPIFFE Workload API.
 ///
 /// Provides one-shot calls and streaming updates for X.509 and JWT SVIDs and bundles.
@@ -50,7 +52,7 @@ impl WorkloadApiClient {
         let channel = connect(&endpoint).await?;
         Ok(Self {
             endpoint,
-            client: SpiffeWorkloadApiClient::with_interceptor(channel, MetadataAdder {}),
+            client: SpiffeWorkloadApiClient::with_interceptor(channel, MetadataAdder::new(None)),
         })
     }
 
@@ -105,7 +107,32 @@ impl WorkloadApiClient {
     pub fn new_with_channel(endpoint: Endpoint, channel: tonic::transport::Channel) -> Self {
         Self {
             endpoint,
-            client: SpiffeWorkloadApiClient::with_interceptor(channel, MetadataAdder {}),
+            client: SpiffeWorkloadApiClient::with_interceptor(channel, MetadataAdder::new(None)),
+        }
+    }
+
+    /// Creates a client from an existing gRPC channel with a custom
+    /// per-RPC metadata interceptor.
+    ///
+    /// The `interceptor` is called on every RPC to inject custom metadata
+    /// (e.g. K8s service account tokens for identity-server authentication).
+    /// The standard `workload.spiffe.io: true` header is always added
+    /// automatically.
+    ///
+    /// This is the primary constructor for identity-server, which requires
+    /// per-RPC authentication metadata over TLS+TCP (unlike standard SPIRE
+    /// which uses Unix domain sockets with implicit OS-level auth).
+    pub fn new_with_channel_and_interceptor(
+        endpoint: Endpoint,
+        channel: tonic::transport::Channel,
+        interceptor: InterceptorFn,
+    ) -> Self {
+        Self {
+            endpoint,
+            client: SpiffeWorkloadApiClient::with_interceptor(
+                channel,
+                MetadataAdder::new(Some(interceptor)),
+            ),
         }
     }
 }

--- a/spiffe/src/workload_api/mod.rs
+++ b/spiffe/src/workload_api/mod.rs
@@ -29,6 +29,7 @@ pub mod error;
 #[cfg(feature = "x509")]
 pub mod x509_context;
 
+pub use client::InterceptorFn;
 pub use client::WorkloadApiClient;
 pub use error::WorkloadApiError;
 


### PR DESCRIPTION
## Context

Upstream rust-spiffe assumes Unix domain socket transport with implicit OS-level authentication (standard SPIRE model). Deployments that use TCP+TLS transport (e.g. identity-server) require callers to inject authentication metadata (such as K8s service account tokens) on every gRPC request. There is currently no hook for custom per-RPC metadata on WorkloadApiClient.

## Changes

• Added InterceptorFn type alias (Arc<dyn Fn(&mut tonic::Request<()>) -> Result<(), tonic::Status> + Send + Sync>) for custom per-RPC metadata injection.
• Extended MetadataAdder with an optional InterceptorFn field, invoked after the standard workload.spiffe.io: true header is inserted.
• Added WorkloadApiClient::new_with_channel_and_interceptor(endpoint, channel, interceptor) constructor.
• Re-exported InterceptorFn at spiffe::workload_api::InterceptorFn and spiffe::InterceptorFn (gated behind workload-api-* features).

## Security

• Advisory: N/A
• No security implications. The interceptor runs in-process on the caller side and does not alter trust boundaries.

## Compatibility

• MSRV: 1.88 (unchanged)
• Breaking changes: none — MetadataAdder is pub(super) and not part of the public API. All existing constructors behave identically.
• Affected crates/features: spiffe crate, workload-api-* feature gates.

## Testing

Covered by CI (make fmt-check, make build, make test, make doc-test, make examples — all pass). Three new unit tests in spiffe/src/workload_api/client/header.rs:
• spiffe_header_always_inserted — verifies the standard header is added with no custom interceptor.
• custom_interceptor_metadata_added — verifies custom metadata appears alongside the SPIFFE header.
• custom_interceptor_error_propagates — verifies interceptor errors surface as tonic::Status.

## Release notes

• Added InterceptorFn type and WorkloadApiClient::new_with_channel_and_interceptor() for injecting custom per-RPC metadata (e.g. authentication tokens for TCP+TLS transports).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxlambrecht/rust-spiffe/342)
<!-- Reviewable:end -->
