### PR TITLE
chore(release): prepare rust-spiffe 0.15 releases

### DIFF
--- a/spiffe-rustls-grpc-examples/Cargo.toml
+++ b/spiffe-rustls-grpc-examples/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-spiffe = { version = "0.14", path = "../spiffe", features = ["x509-source"] }
+spiffe = { version = "0.15", path = "../spiffe", features = ["x509-source"] }
 spiffe-rustls = { path = "../spiffe-rustls", features = ["ring"] }
 
 # gRPC stack

--- a/spiffe-rustls-tokio/CHANGELOG.md
+++ b/spiffe-rustls-tokio/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.3.0] – 2026-05-08
+
+### Breaking changes
+
+- Bumped the `spiffe` dependency from `0.14` to `0.15`. `spiffe-rustls-tokio` exposes `spiffe::SpiffeId` through `PeerIdentity`, so downstream users must use compatible `spiffe` `0.15` types.
+- Updated examples and development dependency to `spiffe-rustls` `0.6`.
+
 ## [0.2.0] – 2026-04-25
 
 ### Breaking changes

--- a/spiffe-rustls-tokio/Cargo.toml
+++ b/spiffe-rustls-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spiffe-rustls-tokio"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -19,7 +19,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dependencies]
-spiffe = { version = "0.14", path = "../spiffe", features = ["x509-source"] }
+spiffe = { version = "0.15", path = "../spiffe", features = ["x509-source"] }
 tokio = { version = "1", default-features = false, features = ["net", "rt"] }
 tokio-rustls = { version = "0.26", default-features = false }
 rustls = { version = "0.23", default-features = false, features = ["std"] }
@@ -28,7 +28,7 @@ thiserror = "2"
 [dev-dependencies]
 anyhow = "1"
 env_logger = "0.11"
-spiffe-rustls = { version = "0.5", path = "../spiffe-rustls" }
+spiffe-rustls = { version = "0.6", path = "../spiffe-rustls" }
 tokio = { version = "1", default-features = false, features = [
     "rt-multi-thread",
     "signal",

--- a/spiffe-rustls-tokio/README.md
+++ b/spiffe-rustls-tokio/README.md
@@ -19,9 +19,9 @@ Add `spiffe-rustls-tokio` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-spiffe-rustls-tokio = "0.2"
-spiffe-rustls = "0.5"
-spiffe = { version = "0.14", features = ["x509-source"] }
+spiffe-rustls-tokio = "0.3"
+spiffe-rustls = "0.6"
+spiffe = { version = "0.15", features = ["x509-source"] }
 ```
 
 ---

--- a/spiffe-rustls/CHANGELOG.md
+++ b/spiffe-rustls/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.6.0] – 2026-05-08
+
+### Breaking changes
+
+- Bumped the `spiffe` dependency from `0.14` to `0.15`. Because `spiffe-rustls` exposes `spiffe` types in its public API, downstream users must use compatible `spiffe` `0.15` types.
+
+### Changed
+
+- Clarified documentation around the default SPIFFE verification posture and the risks of advanced rustls configuration customization.
+
 ## [0.5.0] – 2026-04-25
 
 ### Breaking changes

--- a/spiffe-rustls/Cargo.toml
+++ b/spiffe-rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spiffe-rustls"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -19,7 +19,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dependencies]
-spiffe = { version = "0.14", path = "../spiffe", features = ["x509-source"] }
+spiffe = { version = "0.15", path = "../spiffe", features = ["x509-source"] }
 rustls = { version = "0.23", default-features = false, features = ["std"] }
 tokio = { version = "1", default-features = false, features = ["rt", "sync"] }
 tokio-util = "0.7"

--- a/spiffe/CHANGELOG.md
+++ b/spiffe/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.15.0] – 2026-05-08
+
+### Added
+
+- **WorkloadApiClient:** Added `new_with_channel_and_interceptor(...)` for callers that need to inject custom per-RPC gRPC metadata.
+
 ## [0.14.0] – 2026-04-25
 
 ### Breaking changes

--- a/spiffe/Cargo.toml
+++ b/spiffe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spiffe"
-version = "0.14.0"
+version = "0.15.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/spiffe/README.md
+++ b/spiffe/README.md
@@ -20,16 +20,16 @@ Add `spiffe` to your `Cargo.toml`. All features are opt-in:
 ```toml
 [dependencies]
 # Minimal: only SPIFFE primitives 
-spiffe = "0.14"
+spiffe = "0.15"
 
 # OR X.509 workloads (recommended)
-# spiffe = { version = "0.14", features = ["x509-source"] }
+# spiffe = { version = "0.15", features = ["x509-source"] }
 
 # OR JWT workloads (recommended)
-# spiffe = { version = "0.14", features = ["jwt-source"] }
+# spiffe = { version = "0.15", features = ["jwt-source"] }
 
 # OR Direct Workload API usage
-# spiffe = { version = "0.14", features = ["workload-api"] }
+# spiffe = { version = "0.15", features = ["workload-api"] }
 ```
 
 ---
@@ -275,14 +275,14 @@ backend.
 
 ```toml
 [dependencies]
-spiffe = { version = "0.14", features = ["jwt-verify-rust-crypto"] }
+spiffe = { version = "0.15", features = ["jwt-verify-rust-crypto"] }
 ```
 
 #### Using the AWS-LC backend
 
 ```toml
 [dependencies]
-spiffe = { version = "0.14", features = ["jwt-verify-aws-lc-rs"] }
+spiffe = { version = "0.15", features = ["jwt-verify-aws-lc-rs"] }
 ```
 
 This enables local signature verification using JWT authorities from bundles:
@@ -436,7 +436,7 @@ facade. Events are emitted via `log::debug!`, `log::info!`, `log::warn!`, and `l
 
 ```toml
 [dependencies]
-spiffe = { version = "0.14", features = ["logging"] }
+spiffe = { version = "0.15", features = ["logging"] }
 ```
 
 **Note:** The `logging` feature is not included in the default `workload-api` feature.
@@ -452,7 +452,7 @@ or distributed tracing systems. When both `tracing` and `logging` features are e
 
 ```toml
 [dependencies]
-spiffe = { version = "0.14", features = ["tracing"] }
+spiffe = { version = "0.15", features = ["tracing"] }
 ```
 
 **Note:** The `tracing` and `logging` features are not mutually exclusive. When both
@@ -468,7 +468,7 @@ In addition to the higher-level bundles (`workload-api-x509`, `workload-api-jwt`
 
 ```toml
 [dependencies]
-spiffe = { version = "0.14", features = ["workload-api-core"] }
+spiffe = { version = "0.15", features = ["workload-api-core"] }
 ```
 
 This feature includes:

--- a/spire-api/CHANGELOG.md
+++ b/spire-api/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.7.0] – 2026-05-08
+
+### Breaking changes
+
+- Bumped the `spiffe` dependency from `0.14` to `0.15`. `spire-api` exposes `spiffe` types in its public API, so downstream users must use compatible `spiffe` `0.15` types.
+
 ## [0.6.0] – 2026-04-25
 
 ### Breaking changes

--- a/spire-api/Cargo.toml
+++ b/spire-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spire-api"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ workspace = true
 [dependencies]
 futures = { version = "0.3", default-features = false }
 prost = { version = "0.14", default-features = false }
-spiffe = { version = "0.14", path = "../spiffe", features = ["x509", "jwt", "transport-grpc"] }
+spiffe = { version = "0.15", path = "../spiffe", features = ["x509", "jwt", "transport-grpc"] }
 thiserror = { version = "2", default-features = false }
 tonic = { version = "0.14", default-features = false, features = ["transport", "codegen"] }
 tonic-prost = { version = "0.14", default-features = false }


### PR DESCRIPTION
## Context
Prepare releases for the new `spiffe` Workload API per-RPC metadata interceptor API and align dependent crates that expose `spiffe` types publicly.

## Changes
- Bump `spiffe` to 0.15.0.
- Bump `spiffe-rustls` to 0.6.0 and update its `spiffe` dependency to 0.15.
- Bump `spiffe-rustls-tokio` to 0.3.0 and update its `spiffe` / `spiffe-rustls` references.
- Bump `spire-api` to 0.7.0 and update its `spiffe` dependency to 0.15.
- Update changelogs and README examples.

## Security
- Advisory: none
- Fix: none; release preparation only.

## Compatibility
- MSRV: unchanged, 1.88
- Breaking changes: dependent crates move to `spiffe` 0.15, which is incompatible with `spiffe` 0.14 under Cargo’s 0.x SemVer rules.
- Affected crates/features: `spiffe`, `spiffe-rustls`, `spiffe-rustls-tokio`, `spire-api`, example crate dependency metadata.

## Testing
- `cargo check -p spiffe -p spiffe-rustls -p spiffe-rustls-tokio -p spire-api`

## Release notes
### spiffe 0.15.0
- **WorkloadApiClient:** Added `new_with_channel_and_interceptor(...)` for callers that need to inject custom per-RPC gRPC metadata while preserving the required `workload.spiffe.io: true` header.

### spiffe-rustls 0.6.0
- Bumped the `spiffe` dependency from `0.14` to `0.15`.
- Clarified documentation around the default SPIFFE verification posture and the risks of advanced rustls configuration customization.

### spiffe-rustls-tokio 0.3.0
- Bumped the `spiffe` dependency from `0.14` to `0.15`.
- Updated examples and development dependency to `spiffe-rust

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxlambrecht/rust-spiffe/344)
<!-- Reviewable:end -->
