### PR TITLE
fix(cert): error on oversized URI SAN instead of skipping

### DIFF
--- a/spiffe/src/cert/error.rs
+++ b/spiffe/src/cert/error.rs
@@ -31,6 +31,13 @@ pub enum CertificateError {
     #[error("certificate contains multiple URI SAN entries")]
     MultipleUriSanEntries,
 
+    /// A URI SAN exceeds the maximum length processed by this library.
+    #[error("URI SAN exceeds maximum length ({max} bytes)")]
+    OversizedUriSan {
+        /// Maximum URI SAN length in bytes (inclusive).
+        max: usize,
+    },
+
     /// The certificate contains more than one URI SAN that parses as a SPIFFE ID.
     ///
     /// Kept for compatibility with callers that match this variant specifically.

--- a/spiffe/src/cert/mod.rs
+++ b/spiffe/src/cert/mod.rs
@@ -34,6 +34,7 @@ impl Certificate {
     /// # Errors
     /// - [`CertificateError::MissingSpiffeId`] if no SPIFFE ID is present in the URI SAN.
     /// - [`CertificateError::MultipleUriSanEntries`] if the certificate contains multiple URI SAN entries.
+    /// - [`CertificateError::OversizedUriSan`] if a URI SAN exceeds the maximum allowed length.
     /// - [`CertificateError::ParseX509Certificate`] for parsing errors.
     pub fn spiffe_id(&self) -> Result<SpiffeId, CertificateError> {
         let x509 = parse_der_encoded_bytes_as_x509_certificate(self.as_bytes())?;
@@ -129,6 +130,7 @@ impl std::fmt::Debug for PrivateKey {
 /// # Errors
 /// - [`CertificateError::MissingSpiffeId`] if no SPIFFE ID is present in the URI SAN.
 /// - [`CertificateError::MultipleUriSanEntries`] if the certificate contains multiple URI SAN entries.
+/// - [`CertificateError::OversizedUriSan`] if a URI SAN exceeds the maximum allowed length.
 /// - [`CertificateError::ParseX509Certificate`] for parsing errors.
 pub fn spiffe_id_from_der(der: &[u8]) -> Result<SpiffeId, CertificateError> {
     let x509 = parse_der_encoded_bytes_as_x509_certificate(der)?;

--- a/spiffe/src/cert/parsing.rs
+++ b/spiffe/src/cert/parsing.rs
@@ -164,9 +164,10 @@ pub(crate) fn extract_spiffe_ids_from_uri_san(
             return Err(CertificateError::MultipleUriSanEntries);
         }
 
-        // Skip large junk without allocating/parsing.
         if uri.len() > MAX_URI_LENGTH {
-            continue;
+            return Err(CertificateError::OversizedUriSan {
+                max: MAX_URI_LENGTH,
+            });
         }
 
         if !uri_has_spiffe_scheme(uri) {

--- a/spiffe/tests/x509_svid.rs
+++ b/spiffe/tests/x509_svid.rs
@@ -546,6 +546,17 @@ mod x509_svid_tests {
         generate_leaf_cert_with_uri_sans(&[uri])
     }
 
+    /// SPIFFE URI with total UTF-8 byte length `total_len` (must fit `spiffe://example.org/` + padding).
+    fn spiffe_uri_with_byte_length(total_len: usize) -> String {
+        const PREFIX: &str = "spiffe://example.org/";
+        assert!(
+            total_len >= PREFIX.len(),
+            "total_len must cover SPIFFE URI prefix"
+        );
+        let pad = total_len - PREFIX.len();
+        format!("{PREFIX}{}", "x".repeat(pad))
+    }
+
     #[test]
     fn test_leaf_spiffe_id_with_path_is_accepted() {
         let (cert_der, key_der) =
@@ -573,6 +584,42 @@ mod x509_svid_tests {
         let (cert_der, key_der) = generate_leaf_cert_with_uri_sans(&[
             "spiffe://example.org/workload",
             "https://example.org/not-allowed",
+        ]);
+
+        let result = X509Svid::parse_from_der(&cert_der, &key_der);
+
+        assert_eq!(
+            result.unwrap_err(),
+            X509SvidError::Certificate(CertificateError::MultipleUriSanEntries)
+        );
+    }
+
+    #[test]
+    fn test_leaf_single_oversized_uri_san_is_rejected() {
+        // Matches `MAX_URI_LENGTH` in `spiffe::cert::parsing`.
+        const MAX_URI_LEN: usize = 2048;
+
+        let oversized_uri = spiffe_uri_with_byte_length(MAX_URI_LEN + 1);
+        assert_eq!(oversized_uri.len(), MAX_URI_LEN + 1);
+
+        let (cert_der, key_der) = generate_leaf_cert_with_uri_sans(&[&oversized_uri]);
+
+        let result = X509Svid::parse_from_der(&cert_der, &key_der);
+
+        assert_eq!(
+            result.unwrap_err(),
+            X509SvidError::Certificate(CertificateError::OversizedUriSan { max: MAX_URI_LEN })
+        );
+    }
+
+    #[test]
+    fn test_leaf_valid_spiffe_uri_then_oversized_second_uri_san_is_multiple_entries() {
+        const MAX_URI_LEN: usize = 2048;
+        let oversized_uri = spiffe_uri_with_byte_length(MAX_URI_LEN + 1);
+
+        let (cert_der, key_der) = generate_leaf_cert_with_uri_sans(&[
+            "spiffe://example.org/workload",
+            oversized_uri.as_str(),
         ]);
 
         let result = X509Svid::parse_from_der(&cert_der, &key_der);


### PR DESCRIPTION
## What

Treat URI SAN entries longer than 2048 bytes as `CertificateError::OversizedUriSan { max }` instead of silently skipping them (which could surface as `MissingSpiffeId` when that was the only URI SAN).

Document the new error on `Certificate::spiffe_id and spiffe_id_from_der`.

Add tests for single oversized SAN, multiple URI SANs, and valid SPIFFE + oversized second SAN (still MultipleUriSanEntries).

## Why
Oversized URI SANs are adversarial or malformed input; skipping them hid the failure behind “missing SPIFFE ID,” weakening observability and fail-closed behavior.

## How tested

cargo test -p spiffe --features x509 x509_svid_tests -- --nocapture

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxlambrecht/rust-spiffe/348)
<!-- Reviewable:end -->
