### PR TITLE
refactor(x509): encode non-empty cert chain without leaf panic

### DIFF
--- a/spiffe/src/svid/x509/mod.rs
+++ b/spiffe/src/svid/x509/mod.rs
@@ -10,6 +10,8 @@ use crate::svid::x509::validations::{validate_leaf_certificate, validate_signing
 use std::convert::TryFrom as _;
 use std::sync::Arc;
 
+use self::chain::CertificateChain;
+
 /// Represents a SPIFFE X.509-SVID.
 ///
 /// Contains a [`SpiffeId`], a certificate chain as DER-encoded X.509 certificates,
@@ -20,7 +22,7 @@ use std::sync::Arc;
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct X509Svid {
     spiffe_id: SpiffeId,
-    cert_chain: Vec<Certificate>,
+    cert_chain: CertificateChain,
     private_key: PrivateKey,
     expiry_unix: i64,
     hint: Option<Arc<str>>,
@@ -122,14 +124,10 @@ impl X509Svid {
         private_key_der: &[u8],
         hint: Option<Arc<str>>,
     ) -> Result<Self, X509SvidError> {
-        let cert_chain = to_certificate_vec(cert_chain_der)?;
+        let cert_chain = CertificateChain::try_from_vec(to_certificate_vec(cert_chain_der)?)?;
 
-        let Some((leaf, rest)) = cert_chain.split_first() else {
-            return Err(X509SvidError::EmptyChain);
-        };
-
-        let (spiffe_id, expiry_unix) = validate_leaf_certificate(leaf)?;
-        validate_signing_certificates(rest)?;
+        let (spiffe_id, expiry_unix) = validate_leaf_certificate(cert_chain.leaf())?;
+        validate_signing_certificates(cert_chain.intermediates())?;
         let private_key = PrivateKey::try_from(private_key_der)?;
 
         Ok(Self {
@@ -148,21 +146,12 @@ impl X509Svid {
 
     /// Returns the certificate chain. The first certificate is the leaf certificate.
     pub fn cert_chain(&self) -> &[Certificate] {
-        &self.cert_chain
+        self.cert_chain.as_slice()
     }
 
     /// Returns the leaf certificate.
-    ///
-    /// # Panics
-    ///
-    /// This method will panic if the certificate chain is empty. This should never
-    /// happen with properly constructed `X509Svid` instances, as the constructor
-    /// validates that the chain is non-empty.
-    pub fn leaf(&self) -> &Certificate {
-        #[expect(clippy::panic, reason = "documented behavior")]
-        self.cert_chain
-            .first()
-            .unwrap_or_else(|| panic!("certificate chain is empty"))
+    pub const fn leaf(&self) -> &Certificate {
+        self.cert_chain.leaf()
     }
 
     /// Returns the private key.
@@ -178,5 +167,46 @@ impl X509Svid {
     /// Returns the optional hint provided by the Workload API.
     pub fn hint(&self) -> Option<&str> {
         self.hint.as_deref()
+    }
+}
+
+mod chain {
+    use crate::cert::Certificate;
+    use crate::svid::x509::X509SvidError;
+
+    /// An ordered X.509 certificate chain with a guaranteed leaf certificate.
+    ///
+    /// The first certificate is the leaf and any remaining certificates are
+    /// intermediates. Construction rejects empty chains, so callers can access
+    /// the leaf without a panic path.
+    #[derive(Debug, Clone, Eq, PartialEq)]
+    pub(super) struct CertificateChain {
+        leaf: Certificate,
+        certs: Vec<Certificate>,
+    }
+
+    impl CertificateChain {
+        pub(super) fn try_from_vec(certs: Vec<Certificate>) -> Result<Self, X509SvidError> {
+            let Some(leaf) = certs.first().cloned() else {
+                return Err(X509SvidError::EmptyChain);
+            };
+
+            Ok(Self { leaf, certs })
+        }
+
+        pub(super) const fn leaf(&self) -> &Certificate {
+            &self.leaf
+        }
+
+        pub(super) fn intermediates(&self) -> &[Certificate] {
+            match self.certs.split_first() {
+                Some((_, intermediates)) => intermediates,
+                None => &[],
+            }
+        }
+
+        pub(super) fn as_slice(&self) -> &[Certificate] {
+            &self.certs
+        }
     }
 }

--- a/spiffe/tests/x509_svid.rs
+++ b/spiffe/tests/x509_svid.rs
@@ -30,6 +30,24 @@ mod x509_svid_tests {
     }
 
     #[test]
+    fn test_x509_svid_rejects_empty_der_chain() {
+        let key_bytes: &[u8] = include_bytes!("testdata/svid/x509/1-key.der");
+
+        let result = X509Svid::parse_from_der(&[], key_bytes);
+
+        assert_eq!(result.unwrap_err(), X509SvidError::EmptyChain);
+    }
+
+    #[test]
+    fn test_x509_svid_with_hint_rejects_empty_der_chain() {
+        let key_bytes: &[u8] = include_bytes!("testdata/svid/x509/1-key.der");
+
+        let result = X509Svid::parse_from_der_with_hint(&[], key_bytes, Some("test-hint".into()));
+
+        assert_eq!(result.unwrap_err(), X509SvidError::EmptyChain);
+    }
+
+    #[test]
     fn test_x509_svid_parse_from_single_der() {
         // the cert has a DNS, besides the URI SAN.
         let cert_bytes: &[u8] = include_bytes!("testdata/svid/x509/svid-with-dns.der");
@@ -45,6 +63,24 @@ mod x509_svid_tests {
         assert_eq!(x509_svid.cert_chain().len(), 1);
         assert_eq!(x509_svid.leaf().as_ref(), cert_bytes);
         assert_eq!(x509_svid.private_key().as_ref(), key_bytes);
+    }
+
+    #[test]
+    fn test_x509_svid_leaf_and_chain_preserve_ordering() {
+        let certs_bytes: &[u8] = include_bytes!("testdata/svid/x509/1-svid-chain.der");
+        let key_bytes: &[u8] = include_bytes!("testdata/svid/x509/1-key.der");
+        let expected_chain = split_der_chain(certs_bytes);
+
+        let x509_svid = X509Svid::parse_from_der(certs_bytes, key_bytes).unwrap();
+
+        assert_eq!(
+            x509_svid.leaf().as_ref(),
+            expected_chain.first().unwrap().as_slice()
+        );
+        assert_eq!(x509_svid.cert_chain().len(), expected_chain.len());
+        for (actual, expected) in x509_svid.cert_chain().iter().zip(expected_chain.iter()) {
+            assert_eq!(actual.as_ref(), expected.as_slice());
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Context
`X509Svid::leaf()` documented a panic path if the stored certificate chain were empty. Public constructors already reject empty chains, but the type still stored a plain `Vec<Certificate>`, which left an internal invariant easy to violate during future refactors.

## Changes
- Replace `Vec<Certificate>` storage with a private `CertificateChain` wrapper that enforces a non-empty chain at construction time.
- Make `leaf()` infallible by returning the stored leaf certificate directly (no panic path; remove clippy suppression).
- Preserve `cert_chain()` ordering and behavior via the wrapper’s slice view.
- Add integration tests for empty DER chain rejection (both `parse_from_der` and `parse_from_der_with_hint`) and leaf/chain ordering against split DER fixtures.

## Security
- Advisory: none
- Fix: Removes a library panic path tied to certificate-chain representation and makes the non-empty chain invariant harder to accidentally break in internal code.

## Compatibility
- MSRV: 1.88 (unchanged)
- Breaking changes: none (`X509Svid` public surface unchanged; `leaf` remains `pub fn leaf(&self) -> &Certificate`, now `const`)
- Affected crates/features (if applicable): `spiffe` (`feature = "x509"`)

## Testing
```bash
cargo fmt --all
cargo clippy -p spiffe --features x509 --all-targets -- -D warnings
cargo test -p spiffe --features x509 x509_svid_tests -- --nocapture
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxlambrecht/rust-spiffe/349)
<!-- Reviewable:end -->
