### PR TITLE
chore(release): spiffe 0.15.1 and spiffe-rustls 0.6.1

### DIFF
--- a/spiffe-rustls/CHANGELOG.md
+++ b/spiffe-rustls/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.6.1] - 2026-05-11
+
+### Fixed
+
+- **Outbound TLS server certificate verification:** Removed handling that treated rustls `NotValidForName` and `NotValidForNameContext` errors from `WebPkiServerVerifier` as successful verification after combined chain-and-name validation. That behavior assumed path validation had already succeeded whenever rustls reported a TLS name mismatch, which is not a safe invariant. In some cases, this could allow a handshake to succeed without a validated trust path. Path validation is now performed explicitly with `verify_server_cert_signed_by_trust_anchor` before SPIFFE ID authorization (#346).
+
+
 ## [0.6.0] – 2026-05-08
 
 ### Breaking changes

--- a/spiffe-rustls/Cargo.toml
+++ b/spiffe-rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spiffe-rustls"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/spiffe/CHANGELOG.md
+++ b/spiffe/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.15.1] - 2026-05-11
+
+### Fixed
+
+- **Trust bundles and federation:** Fail closed when trust-domain selection excludes all available bundles, instead of treating verification as successful (#350).
+- **Certificates:** Return an error when a URI SAN exceeds size limits, instead of silently skipping it (#348).
+- **X.509-SVID:** Avoid a panic when encoding a non-empty certificate chain whose leaf certificate was extracted separately (#349).
+- **JWT source and Workload API:** Retry JWT-SVID fetches only for transient errors (#347).
+
+
 ## [0.15.0] – 2026-05-08
 
 ### Added

--- a/spiffe/Cargo.toml
+++ b/spiffe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spiffe"
-version = "0.15.0"
+version = "0.15.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## Context

Ship patch releases for fixes merged on `main` after the `spiffe-0.15.0` tag: `spiffe` correctness and hardening fixes (#347-#350), plus the `spiffe-rustls` outbound server certificate verification fix (#346).

No coordinated bump is required for `spire-api`, `spiffe-rustls-tokio`, or the gRPC examples crate for this release set.

## Changes

- **`spiffe` `0.15.1`:** Bump `version` in `spiffe/Cargo.toml` and update `spiffe/CHANGELOG.md`.
- **`spiffe-rustls` `0.6.1`:** Bump `version` in `spiffe-rustls/Cargo.toml` and update `spiffe-rustls/CHANGELOG.md` with release notes for #346.

Workspace `path` + `version` dependencies already use the `spiffe` `0.15` and `spiffe-rustls` `0.6` minor lines. This PR does not change those dependency ranges; it only updates the published patch versions.

## Security

Review should focus on the security-sensitive fixes included in these patch releases:

- Trust-bundle and federation fail-closed behavior (#350).
- URI SAN size-limit handling (#348).
- JWT-SVID fetch retry semantics (#347).
- X.509-SVID certificate chain encoding (#349).
- `spiffe-rustls` outbound server certificate verification, ensuring path validation cannot be short-circuited by TLS name-check errors (#346).

## Compatibility

- **MSRV:** Unchanged, `1.88` for the workspace.
- **Breaking changes:** None. These are patch releases only.
- **Downstream impact:** Users on the `spiffe` `0.15` and `spiffe-rustls` `0.6` release lines can upgrade within the same minor version. No bump is needed for `spire-api` or `spiffe-rustls-tokio`.

## Testing

Covered by CI with:

```sh
make spiffe-ci-test spire-api-ci-test spiffe-rustls-ci-test spiffe-rustls-tokio-ci-test
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxlambrecht/rust-spiffe/351)
<!-- Reviewable:end -->
