### PR TITLE
chore(rustls): prepare 0.6.2 release

### DIFF
--- a/spiffe-rustls/CHANGELOG.md
+++ b/spiffe-rustls/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.6.2] - 2026-06-07
 
 ### Security
 

--- a/spiffe-rustls/Cargo.toml
+++ b/spiffe-rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spiffe-rustls"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## Context

Prepare the `spiffe-rustls` crate for the `0.6.2` release.

## Changes

- Bump `spiffe-rustls` from `0.6.1` to `0.6.2`.
- Promote the changelog entry from `[Unreleased]` to `[0.6.2] - 2026-06-07`.

## Security

- Advisory: none
- Fix: release includes verifier hardening that rejects signing-capable peer certificates as X509-SVID leaf identities.

## Compatibility

- MSRV: unchanged
- Breaking changes: none
- Affected crates/features: `spiffe-rustls`

## Testing

- `cargo check -p spiffe-rustls`
- `cargo test -p spiffe-rustls verifier`

## Release notes

Reject peer certificates that are signing-capable (`cA=true`, `keyCertSign`, or `cRLSign`) before accepting them as X509-SVID leaf identities. This aligns the client-side server verifier and server-side client verifier with X509-SVID leaf validation requirements; rejected peers fail with `Error::InvalidLeaf`. The verifier cache now keys entries by full certificate DER and caches the leaf check with the extracted SPIFFE ID, keeping cache hits exact without re-parsing certificates.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxlambrecht/rust-spiffe/356)
<!-- Reviewable:end -->
