### PR TITLE
fix(spiffe): narrow source feature dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ SPIFFE_ALL_FEATURES := \
   workload-api-core \
   workload-api-x509 \
   workload-api-jwt \
-  workload-api-full \
+  workload-api \
   x509-source \
   jwt-source \
   jwt \
@@ -139,10 +139,10 @@ SPIFFE_ALL_FEATURES := \
   jwt-verify-aws-lc-rs \
   logging \
   tracing \
-  workload-api-full,logging \
-  workload-api-full,tracing \
-  workload-api-full,tracing,jwt-verify-rust-crypto \
-  workload-api-full,tracing,jwt-verify-aws-lc-rs \
+  workload-api,logging \
+  workload-api,tracing \
+  workload-api,tracing,jwt-verify-rust-crypto \
+  workload-api,tracing,jwt-verify-aws-lc-rs \
   x509-source,logging \
   x509-source,tracing \
   jwt-source,logging \

--- a/spiffe/CHANGELOG.md
+++ b/spiffe/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **Features:** `x509-source` now enables only `workload-api-x509` and `jwt-source` now enables only `workload-api-jwt`, instead of both enabling the full `workload-api` (X.509 + JWT). Enabling a single source feature no longer compiles the other SVID type's parsing stack, shrinking the dependency tree and build time for workloads that use only X.509 or only JWT.
+
+
 ## [0.15.1] - 2026-05-11
 
 ### Fixed

--- a/spiffe/CHANGELOG.md
+++ b/spiffe/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## [Unreleased]
 
-### Changed
+### Breaking changes
 
-- **Features:** `x509-source` now enables only `workload-api-x509` and `jwt-source` now enables only `workload-api-jwt`, instead of both enabling the full `workload-api` (X.509 + JWT). Enabling a single source feature no longer compiles the other SVID type's parsing stack, shrinking the dependency tree and build time for workloads that use only X.509 or only JWT.
+- **Features:** `x509-source` now enables only `workload-api-x509`, and `jwt-source` only `workload-api-jwt`, so each source no longer pulls in the other SVID type's parsing dependencies.
+- **Features:** Removed the redundant `workload-api-full` feature; use `workload-api` instead.
 
 
 ## [0.15.1] - 2026-05-11

--- a/spiffe/Cargo.toml
+++ b/spiffe/Cargo.toml
@@ -76,6 +76,8 @@ openssl = { version = "0.10", features = ["vendored"] }
 [features]
 default = []
 
+# --- Base capabilities (types, parsing, transport) ---
+
 # Endpoint parsing/normalization only (no async/runtime deps).
 transport = ["dep:url"]
 
@@ -84,6 +86,11 @@ transport-grpc = ["transport", "dep:tokio", "dep:tonic", "dep:tower", "dep:hyper
 
 # X.509 types + parsing.
 x509 = ["dep:x509-parser", "dep:pkcs8", "dep:zeroize"]
+
+# JWT types + token parsing (no signature verification).
+jwt = ["dep:serde", "dep:serde_json", "dep:time", "dep:base64ct", "dep:zeroize"]
+
+# --- Workload API client ---
 
 # Workload API core substrate: transport, runtime, and protobuf dependencies.
 # This feature provides the infrastructure for the Workload API client without
@@ -113,19 +120,22 @@ workload-api-full = ["workload-api-x509", "workload-api-jwt"]
 # This feature enables the full Workload API client with both X.509 and JWT support.
 workload-api = ["workload-api-full"]
 
+# --- High-level watcher/caching sources ---
+
 # X.509 watcher/caching API built on the Workload API.
-x509-source = ["workload-api"]
+# Depends on the X.509-only Workload API bundle to avoid pulling in JWT dependencies.
+x509-source = ["workload-api-x509"]
 
 # JWT watcher/caching API built on the Workload API.
-jwt-source = ["workload-api", "jwt"]
+# Depends on the JWT-only Workload API bundle to avoid pulling in X.509 dependencies.
+jwt-source = ["workload-api-jwt"]
 
-# JWT types + token parsing (no signature verification).
-jwt = ["dep:serde", "dep:serde_json", "dep:time", "dep:base64ct", "dep:zeroize"]
+# --- JWT signature verification backends (select exactly one) ---
 
-# JWT signature verification via `jsonwebtoken` (select exactly one backend).
 jwt-verify-rust-crypto = ["jwt", "dep:jsonwebtoken", "jsonwebtoken/rust_crypto"]
 jwt-verify-aws-lc-rs = ["jwt", "dep:jsonwebtoken", "jsonwebtoken/aws_lc_rs"]
 
-# Observability backends (optional).
+# --- Observability backends (optional) ---
+
 logging = ["dep:log"]
 tracing = ["dep:tracing", "logging"]

--- a/spiffe/Cargo.toml
+++ b/spiffe/Cargo.toml
@@ -113,12 +113,8 @@ workload-api-x509 = ["workload-api-core", "x509"]
 # Workload API with JWT capability.
 workload-api-jwt = ["workload-api-core", "jwt"]
 
-# Workload API with both X.509 and JWT capabilities (full bundle).
-workload-api-full = ["workload-api-x509", "workload-api-jwt"]
-
-# Async Workload API client (backward compatibility alias for `workload-api-full`).
-# This feature enables the full Workload API client with both X.509 and JWT support.
-workload-api = ["workload-api-full"]
+# Workload API client with both X.509 and JWT capabilities.
+workload-api = ["workload-api-x509", "workload-api-jwt"]
 
 # --- High-level watcher/caching sources ---
 

--- a/spiffe/README.md
+++ b/spiffe/README.md
@@ -463,7 +463,7 @@ features are enabled, events are emitted via `tracing`.
 ### Workload API core (advanced)
 
 In addition to the higher-level bundles (`workload-api-x509`, `workload-api-jwt`,
-`workload-api`, `workload-api-full`), the crate exposes a lower-level
+`workload-api`), the crate exposes a lower-level
 `workload-api-core` feature:
 
 ```toml

--- a/spiffe/src/lib.rs
+++ b/spiffe/src/lib.rs
@@ -82,7 +82,6 @@
 //! | `workload-api-x509` | Workload API client + X.509 support (no JWT) |
 //! | `workload-api-jwt` | Workload API client + JWT support (no X.509) |
 //! | `workload-api` | Workload API client with both X.509 + JWT support |
-//! | `workload-api-full` | Alias/bundle for both X.509 + JWT support (same capability as `workload-api`) |
 //!
 //! ### Advanced / compositional
 //!
@@ -96,7 +95,7 @@
 //!
 //! - The `x509` feature gates heavy X.509 parsing dependencies.
 //! - For direct Workload API usage, use `workload-api-x509` or `workload-api-jwt` when you only need one,
-//!   and `workload-api` (or `workload-api-full`) when you need both.
+//!   and `workload-api` when you need both.
 //!
 //! ## X.509
 //!

--- a/spiffe/src/lib.rs
+++ b/spiffe/src/lib.rs
@@ -43,7 +43,7 @@
 //! For direct Workload API access, use [`WorkloadApiClient`] (requires a `workload-api-*` feature):
 //!
 //! ```no_run
-//! # #[cfg(feature = "workload-api")]
+//! # #[cfg(feature = "workload-api-jwt")]
 //! # async fn example() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 //! use spiffe::WorkloadApiClient;
 //!
@@ -170,12 +170,7 @@ compile_error!(
      Choose exactly one: `jwt-verify-rust-crypto` or `jwt-verify-aws-lc-rs`."
 );
 
-#[cfg(any(
-    feature = "workload-api",
-    feature = "workload-api-x509",
-    feature = "workload-api-jwt",
-    feature = "workload-api-full"
-))]
+#[cfg(any(feature = "workload-api-x509", feature = "workload-api-jwt"))]
 pub mod workload_api;
 
 #[cfg(feature = "x509-source")]
@@ -202,18 +197,9 @@ pub use crate::bundle::x509::{X509Bundle, X509BundleError, X509BundleSet};
 // Workload API - Common types
 //
 // WorkloadApiClient and X509Context. Available with `workload-api` feature.
-#[cfg(any(
-    feature = "workload-api",
-    feature = "workload-api-x509",
-    feature = "workload-api-full"
-))]
+#[cfg(feature = "workload-api-x509")]
 pub use crate::workload_api::X509Context;
-#[cfg(any(
-    feature = "workload-api",
-    feature = "workload-api-x509",
-    feature = "workload-api-jwt",
-    feature = "workload-api-full"
-))]
+#[cfg(any(feature = "workload-api-x509", feature = "workload-api-jwt"))]
 pub use crate::workload_api::{InterceptorFn, WorkloadApiClient, WorkloadApiError};
 
 // X.509 Source

--- a/spiffe/src/workload_api/client/mod.rs
+++ b/spiffe/src/workload_api/client/mod.rs
@@ -171,7 +171,7 @@ impl WorkloadApiClient {
         }
     }
 
-    #[cfg(all(test, feature = "jwt"))]
+    #[cfg(all(test, feature = "jwt-source"))]
     pub(crate) fn new_with_jwt_fetch_hook(endpoint: Endpoint, hook: JwtFetchTestHook) -> Self {
         let channel = tonic::transport::Endpoint::from_static("http://127.0.0.1:1").connect_lazy();
 

--- a/spiffe/src/workload_api/error.rs
+++ b/spiffe/src/workload_api/error.rs
@@ -106,12 +106,7 @@ impl From<tonic::Status> for WorkloadApiError {
     }
 }
 
-#[cfg(any(
-    feature = "workload-api",
-    feature = "workload-api-x509",
-    feature = "workload-api-jwt",
-    feature = "workload-api-full"
-))]
+#[cfg(any(feature = "workload-api-x509", feature = "workload-api-jwt"))]
 impl From<tonic::transport::Error> for WorkloadApiError {
     fn from(e: tonic::transport::Error) -> Self {
         Self::Transport(TransportError::Tonic(e))

--- a/spiffe/src/workload_api/error.rs
+++ b/spiffe/src/workload_api/error.rs
@@ -9,12 +9,7 @@ use crate::{JwtBundleError, JwtSvidError};
 #[cfg(feature = "x509")]
 use crate::{X509BundleError, X509SvidError};
 
-#[cfg(any(
-    feature = "workload-api",
-    feature = "workload-api-x509",
-    feature = "workload-api-jwt",
-    feature = "workload-api-full"
-))]
+#[cfg(any(feature = "workload-api-x509", feature = "workload-api-jwt"))]
 use crate::transport::TransportError;
 
 /// Errors produced by Workload API operations.
@@ -63,12 +58,7 @@ pub enum WorkloadApiError {
     HintNotFound(String),
 
     /// Errors returned by the underlying transport.
-    #[cfg(any(
-        feature = "workload-api",
-        feature = "workload-api-x509",
-        feature = "workload-api-jwt",
-        feature = "workload-api-full"
-    ))]
+    #[cfg(any(feature = "workload-api-x509", feature = "workload-api-jwt"))]
     #[error(transparent)]
     Transport(#[from] TransportError),
 
@@ -97,12 +87,7 @@ pub enum WorkloadApiError {
     SpiffeId(#[from] SpiffeIdError),
 }
 
-#[cfg(any(
-    feature = "workload-api",
-    feature = "workload-api-x509",
-    feature = "workload-api-jwt",
-    feature = "workload-api-full"
-))]
+#[cfg(any(feature = "workload-api-x509", feature = "workload-api-jwt"))]
 impl From<tonic::Status> for WorkloadApiError {
     fn from(status: tonic::Status) -> Self {
         use tonic::Code;

--- a/spiffe/tests/workload_api_client.rs
+++ b/spiffe/tests/workload_api_client.rs
@@ -3,7 +3,7 @@
 #![expect(unused_crate_dependencies, reason = "used in the library target")]
 
 #[cfg(test)]
-#[cfg(feature = "workload-api-full")]
+#[cfg(feature = "workload-api")]
 mod integration_tests_workload_api_client {
     use futures::StreamExt as _;
     use spiffe::bundle::BundleSource as _;


### PR DESCRIPTION
## Context
Reduce unnecessary dependency and build-time coupling between the high-level X.509 and JWT source features in the `spiffe` crate.

## Changes
- Changed `x509-source` to depend on `workload-api-x509` instead of the full `workload-api`.
- Changed `jwt-source` to depend on `workload-api-jwt` instead of the full `workload-api`.
- Updated Workload API `cfg` gates to use the narrower `workload-api-x509` / `workload-api-jwt` feature split.

## Security
- Advisory: none
- Fix: avoids compiling unrelated parsing stacks for single-source consumers without weakening SPIFFE validation or trust behavior.

## Compatibility
- MSRV: unchanged
- Breaking changes: feature-behavior change for consumers who relied on `x509-source` implicitly enabling JWT APIs, or `jwt-source` implicitly enabling X.509 APIs.
- Affected crates/features: `spiffe` feature flags `x509-source`, `jwt-source`, `workload-api-x509`, `workload-api-jwt`, `workload-api-full`, `workload-api`.

## Testing
Not run while preparing this PR text. Recommended feature-matrix checks:
- `cargo test -p spiffe --no-default-features --features x509-source`
- `cargo test -p spiffe --no-default-features --features jwt-source`
- `cargo test -p spiffe --no-default-features --features workload-api-full`

## Release notes
### Changed
- **Features:** `x509-source` now enables only `workload-api-x509` and `jwt-source` now enables only `workload-api-jwt`, instead of both enabling the full `workload-api` stack. Users who relied on implicit cross-SVID APIs should enable the missing feature explicitly or use `workload-api-full`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxlambrecht/rust-spiffe/357)
<!-- Reviewable:end -->
