### PR TITLE
feat(source)standardize source config re-exports

### DIFF
--- a/spiffe/CHANGELOG.md
+++ b/spiffe/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **Features:** `x509-source` now enables only `workload-api-x509`, and `jwt-source` only `workload-api-jwt`, so each source no longer pulls in the other SVID type's parsing dependencies.
 - **Features:** Removed the redundant `workload-api-full` feature; use `workload-api` instead.
+- **Re-exports:** Dropped the unprefixed `ReconnectConfig` and `ResourceLimits` re-exports at the crate root; use the `X509`/`Jwt`-prefixed aliases (`X509ReconnectConfig`, `X509ResourceLimits`, `JwtReconnectConfig`, `JwtResourceLimits`) or the `x509_source`/`jwt_source` module paths.
 
 
 ## [0.15.1] - 2026-05-11

--- a/spiffe/src/jwt_source/builder.rs
+++ b/spiffe/src/jwt_source/builder.rs
@@ -62,22 +62,22 @@ pub(super) fn normalize_reconnect(reconnect: ReconnectConfig) -> ReconnectConfig
 /// # Examples
 ///
 /// ```rust
-/// use spiffe::jwt_source::ResourceLimits;
+/// use spiffe::JwtResourceLimits;
 ///
 /// // Limited resources
-/// let limits = ResourceLimits {
+/// let limits = JwtResourceLimits {
 ///     max_bundles: Some(200),
 ///     max_bundle_jwks_bytes: Some(4 * 1024 * 1024), // 4MB
 /// };
 ///
 /// // Unlimited (no limits enforced)
-/// let unlimited = ResourceLimits {
+/// let unlimited = JwtResourceLimits {
 ///     max_bundles: None,
 ///     max_bundle_jwks_bytes: None,
 /// };
 ///
 /// // Mixed (some limits, some unlimited)
-/// let mixed = ResourceLimits {
+/// let mixed = JwtResourceLimits {
 ///     max_bundles: Some(50),
 ///     max_bundle_jwks_bytes: None,  // Unlimited JWKS bytes
 /// };
@@ -114,9 +114,9 @@ impl ResourceLimits {
     /// # Examples
     ///
     /// ```rust
-    /// use spiffe::jwt_source::ResourceLimits;
+    /// use spiffe::JwtResourceLimits;
     ///
-    /// let unlimited = ResourceLimits::unlimited();
+    /// let unlimited = JwtResourceLimits::unlimited();
     /// assert_eq!(unlimited.max_bundles, None);
     /// assert_eq!(unlimited.max_bundle_jwks_bytes, None);
     /// ```
@@ -134,9 +134,9 @@ impl ResourceLimits {
     /// # Examples
     ///
     /// ```rust
-    /// use spiffe::jwt_source::ResourceLimits;
+    /// use spiffe::JwtResourceLimits;
     ///
-    /// let limits = ResourceLimits::default_limits();
+    /// let limits = JwtResourceLimits::default_limits();
     /// assert_eq!(limits.max_bundles, Some(200));
     /// ```
     pub fn default_limits() -> Self {
@@ -159,14 +159,14 @@ impl ResourceLimits {
 /// # Example
 ///
 /// ```no_run
-/// use spiffe::jwt_source::{ResourceLimits, JwtSource, JwtSourceBuilder};
+/// use spiffe::{JwtResourceLimits, JwtSource, JwtSourceBuilder};
 /// use std::time::Duration;
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let source = JwtSource::builder()
 ///     .endpoint("unix:/tmp/spire-agent/public/api.sock")
 ///     .reconnect_backoff(Duration::from_secs(1), Duration::from_secs(30))
-///     .resource_limits(ResourceLimits {
+///     .resource_limits(JwtResourceLimits {
 ///         max_bundles: Some(500),
 ///         max_bundle_jwks_bytes: Some(5 * 1024 * 1024),
 ///     })
@@ -302,16 +302,16 @@ impl JwtSourceBuilder {
     /// # Examples
     ///
     /// ```no_run
-    /// use spiffe::jwt_source::{ResourceLimits, JwtSourceBuilder};
+    /// use spiffe::{JwtResourceLimits, JwtSourceBuilder};
     ///
-    /// let limits = ResourceLimits {
+    /// let limits = JwtResourceLimits {
     ///     max_bundles: Some(500),
     ///     max_bundle_jwks_bytes: Some(5 * 1024 * 1024), // 5MB
     /// };
     /// let builder = JwtSourceBuilder::new().resource_limits(limits);
     ///
     /// // Or disable limits:
-    /// let unlimited = ResourceLimits::unlimited();
+    /// let unlimited = JwtResourceLimits::unlimited();
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     #[must_use]

--- a/spiffe/src/lib.rs
+++ b/spiffe/src/lib.rs
@@ -204,8 +204,9 @@ pub use crate::workload_api::{InterceptorFn, WorkloadApiClient, WorkloadApiError
 // X.509 Source
 //
 // High-level watcher/caching abstraction. Available with `x509-source` feature.
-// Primary types are re-exported at the crate root.
-// For advanced configuration types, see the [`x509_source`] module.
+// Primary types are re-exported at the crate root. Configuration types are re-exported with
+// `X509`-prefixed names (mirroring the `Jwt`-prefixed JWT aliases) so the two sources do not
+// collide at the crate root; the unprefixed names remain available via the [`x509_source`] module.
 #[cfg(feature = "x509-source")]
 pub use crate::x509_source::{
     ReconnectConfig as X509ReconnectConfig, ResourceLimits as X509ResourceLimits, X509Source,
@@ -215,19 +216,11 @@ pub use crate::x509_source::{
 // JWT Source
 //
 // High-level watcher/caching abstraction for JWT bundles. Available with `jwt-source` feature.
-// Primary types are re-exported at the crate root.
-// For advanced configuration types, see the [`jwt_source`] module.
+// Primary types are re-exported at the crate root. Configuration types are re-exported with
+// `Jwt`-prefixed names (mirroring the `X509`-prefixed X.509 aliases) so the two sources do not
+// collide at the crate root; the unprefixed names remain available via the [`jwt_source`] module.
 #[cfg(feature = "jwt-source")]
 pub use crate::jwt_source::{
-    JwtSource,
-    JwtSourceBuilder,
-    JwtSourceError,
-    JwtSourceUpdates,
-    // Configuration types: both generic and JWT-specific aliases are available.
-    // Use the aliased names (`JwtReconnectConfig`, `JwtResourceLimits`) when
-    // both X.509 and JWT sources are enabled to avoid ambiguity.
-    ReconnectConfig,
-    ReconnectConfig as JwtReconnectConfig,
-    ResourceLimits,
-    ResourceLimits as JwtResourceLimits,
+    JwtSource, JwtSourceBuilder, JwtSourceError, JwtSourceUpdates,
+    ReconnectConfig as JwtReconnectConfig, ResourceLimits as JwtResourceLimits,
 };


### PR DESCRIPTION
## Context
The crate root exposed unprefixed `ReconnectConfig` and `ResourceLimits` aliases that resolved to the JWT source
types, which was ambiguous alongside the X.509 source config types.

## Changes
- Remove the unprefixed `ReconnectConfig` and `ResourceLimits` crate-root re-exports.
- Keep symmetric root aliases: `X509ReconnectConfig`, `X509ResourceLimits`,
  `JwtReconnectConfig`, and `JwtResourceLimits`.
- Update JWT source doc examples to use `JwtResourceLimits` for parity with the
  X.509 source docs.
- Add a changelog entry.

## Security
- Advisory: N/A
- Fix: N/A; this is an API clarity change.

## Compatibility
- MSRV: unchanged
- Breaking changes: `spiffe::ReconnectConfig` and `spiffe::ResourceLimits` are removed.

## Testing
- `cargo test -p spiffe --no-default-features --features "x509-source,jwt-source,jwt-verify-rust-crypto" --doc`
- `cargo clippy -p spiffe --no-default-features --features "x509-source,jwt-source,jwt-verify-rust-crypto" --all-targets -- -D warnings`

## Release notes
- **Re-exports:** Dropped the unprefixed `ReconnectConfig` and `ResourceLimits`
  re-exports at the crate root; use the `X509`/`Jwt`-prefixed aliases
  (`X509ReconnectConfig`, `X509ResourceLimits`, `JwtReconnectConfig`,
  `JwtResourceLimits`) or the `x509_source`/`jwt_source` module paths.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxlambrecht/rust-spiffe/358)
<!-- Reviewable:end -->
