### PR TITLE
feat(source): make source config types non-exhaustive and add constructors

### DIFF
--- a/spiffe/CHANGELOG.md
+++ b/spiffe/CHANGELOG.md
@@ -7,7 +7,7 @@
 - **Features:** `x509-source` now enables only `workload-api-x509`, and `jwt-source` only `workload-api-jwt`, so each source no longer pulls in the other SVID type's parsing dependencies.
 - **Features:** Removed the redundant `workload-api-full` feature; use `workload-api` instead.
 - **Re-exports:** Dropped the unprefixed `ReconnectConfig` and `ResourceLimits` re-exports at the crate root; use the `X509`/`Jwt`-prefixed aliases (`X509ReconnectConfig`, `X509ResourceLimits`, `JwtReconnectConfig`, `JwtResourceLimits`) or the `x509_source`/`jwt_source` module paths.
-
+- **Source limits:** Marked `X509ResourceLimits` and `JwtResourceLimits`; construct resource limits with `new`, `default`, `default_limits`, or `unlimited`.
 
 ## [0.15.1] - 2026-05-11
 

--- a/spiffe/src/jwt_source/builder.rs
+++ b/spiffe/src/jwt_source/builder.rs
@@ -65,23 +65,21 @@ pub(super) fn normalize_reconnect(reconnect: ReconnectConfig) -> ReconnectConfig
 /// use spiffe::JwtResourceLimits;
 ///
 /// // Limited resources
-/// let limits = JwtResourceLimits {
-///     max_bundles: Some(200),
-///     max_bundle_jwks_bytes: Some(4 * 1024 * 1024), // 4MB
-/// };
+/// let limits = JwtResourceLimits::new(
+///     Some(200),
+///     Some(4 * 1024 * 1024), // 4MB
+/// );
 ///
 /// // Unlimited (no limits enforced)
-/// let unlimited = JwtResourceLimits {
-///     max_bundles: None,
-///     max_bundle_jwks_bytes: None,
-/// };
+/// let unlimited = JwtResourceLimits::unlimited();
 ///
 /// // Mixed (some limits, some unlimited)
-/// let mixed = JwtResourceLimits {
-///     max_bundles: Some(50),
-///     max_bundle_jwks_bytes: None,  // Unlimited JWKS bytes
-/// };
+/// let mixed = JwtResourceLimits::new(
+///     Some(50),
+///     None, // Unlimited JWKS bytes
+/// );
 /// ```
+#[non_exhaustive]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ResourceLimits {
     /// Maximum number of bundles allowed in a bundle set.
@@ -109,6 +107,18 @@ impl Default for ResourceLimits {
 }
 
 impl ResourceLimits {
+    /// Creates a `ResourceLimits` with explicit limits.
+    ///
+    /// Use `None` for unlimited (no limit enforced), or `Some(usize)` for a
+    /// specific limit.
+    #[must_use]
+    pub const fn new(max_bundles: Option<usize>, max_bundle_jwks_bytes: Option<usize>) -> Self {
+        Self {
+            max_bundles,
+            max_bundle_jwks_bytes,
+        }
+    }
+
     /// Creates a `ResourceLimits` with all limits set to unlimited (no limits enforced).
     ///
     /// # Examples
@@ -166,10 +176,10 @@ impl ResourceLimits {
 /// let source = JwtSource::builder()
 ///     .endpoint("unix:/tmp/spire-agent/public/api.sock")
 ///     .reconnect_backoff(Duration::from_secs(1), Duration::from_secs(30))
-///     .resource_limits(JwtResourceLimits {
-///         max_bundles: Some(500),
-///         max_bundle_jwks_bytes: Some(5 * 1024 * 1024),
-///     })
+///     .resource_limits(JwtResourceLimits::new(
+///         Some(500),
+///         Some(5 * 1024 * 1024),
+///     ))
 ///     .build()
 ///     .await?;
 /// # Ok(())
@@ -304,10 +314,10 @@ impl JwtSourceBuilder {
     /// ```no_run
     /// use spiffe::{JwtResourceLimits, JwtSourceBuilder};
     ///
-    /// let limits = JwtResourceLimits {
-    ///     max_bundles: Some(500),
-    ///     max_bundle_jwks_bytes: Some(5 * 1024 * 1024), // 5MB
-    /// };
+    /// let limits = JwtResourceLimits::new(
+    ///     Some(500),
+    ///     Some(5 * 1024 * 1024), // 5MB
+    /// );
     /// let builder = JwtSourceBuilder::new().resource_limits(limits);
     ///
     /// // Or disable limits:

--- a/spiffe/src/x509_source/builder.rs
+++ b/spiffe/src/x509_source/builder.rs
@@ -65,26 +65,23 @@ pub(super) fn normalize_reconnect(reconnect: ReconnectConfig) -> ReconnectConfig
 /// use spiffe::X509ResourceLimits;
 ///
 /// // Limited resources
-/// let limits = X509ResourceLimits {
-///     max_svids: Some(100),
-///     max_bundles: Some(200),
-///     max_bundle_der_bytes: Some(4 * 1024 * 1024), // 4MB
-/// };
+/// let limits = X509ResourceLimits::new(
+///     Some(100),
+///     Some(200),
+///     Some(4 * 1024 * 1024), // 4MB
+/// );
 ///
 /// // Unlimited (no limits enforced)
-/// let unlimited = X509ResourceLimits {
-///     max_svids: None,
-///     max_bundles: None,
-///     max_bundle_der_bytes: None,
-/// };
+/// let unlimited = X509ResourceLimits::unlimited();
 ///
 /// // Mixed (some limits, some unlimited)
-/// let mixed = X509ResourceLimits {
-///     max_svids: Some(50),
-///     max_bundles: None,  // Unlimited bundles
-///     max_bundle_der_bytes: Some(1024 * 1024), // 1MB
-/// };
+/// let mixed = X509ResourceLimits::new(
+///     Some(50),
+///     None, // Unlimited bundles
+///     Some(1024 * 1024), // 1MB
+/// );
 /// ```
+#[non_exhaustive]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ResourceLimits {
     /// Maximum number of SVIDs allowed in a context.
@@ -117,6 +114,23 @@ impl Default for ResourceLimits {
 }
 
 impl ResourceLimits {
+    /// Creates a `ResourceLimits` with explicit limits.
+    ///
+    /// Use `None` for unlimited (no limit enforced), or `Some(usize)` for a
+    /// specific limit.
+    #[must_use]
+    pub const fn new(
+        max_svids: Option<usize>,
+        max_bundles: Option<usize>,
+        max_bundle_der_bytes: Option<usize>,
+    ) -> Self {
+        Self {
+            max_svids,
+            max_bundles,
+            max_bundle_der_bytes,
+        }
+    }
+
     /// Creates a `ResourceLimits` with all limits set to unlimited (no limits enforced).
     ///
     /// # Examples
@@ -173,11 +187,11 @@ impl ResourceLimits {
 /// let source = X509Source::builder()
 ///     .endpoint("unix:/tmp/spire-agent/public/api.sock")
 ///     .reconnect_backoff(Duration::from_secs(1), Duration::from_secs(30))
-///     .resource_limits(X509ResourceLimits {
-///         max_svids: Some(100),
-///         max_bundles: Some(500),
-///         max_bundle_der_bytes: Some(5 * 1024 * 1024),
-///     })
+///     .resource_limits(X509ResourceLimits::new(
+///         Some(100),
+///         Some(500),
+///         Some(5 * 1024 * 1024),
+///     ))
 ///     .build()
 ///     .await?;
 /// # Ok(())
@@ -359,11 +373,11 @@ impl X509SourceBuilder {
     /// ```no_run
     /// use spiffe::{X509ResourceLimits, X509SourceBuilder};
     ///
-    /// let limits = X509ResourceLimits {
-    ///     max_svids: Some(50),
-    ///     max_bundles: Some(500),
-    ///     max_bundle_der_bytes: Some(5 * 1024 * 1024), // 5MB
-    /// };
+    /// let limits = X509ResourceLimits::new(
+    ///     Some(50),
+    ///     Some(500),
+    ///     Some(5 * 1024 * 1024), // 5MB
+    /// );
     /// let builder = X509SourceBuilder::new().resource_limits(limits);
     ///
     /// // Or disable limits:

--- a/spiffe/tests/jwt_source.rs
+++ b/spiffe/tests/jwt_source.rs
@@ -274,10 +274,7 @@ mod integration_tests_jwt_source {
     #[ignore = "requires running SPIFFE Workload API"]
     async fn test_resource_limits() {
         // Test with very restrictive limits (should still work if actual values are below limits)
-        let limits = ResourceLimits {
-            max_bundles: Some(10),
-            max_bundle_jwks_bytes: Some(1024 * 1024), // 1MB
-        };
+        let limits = ResourceLimits::new(Some(10), Some(1024 * 1024));
 
         let source = JwtSourceBuilder::new()
             .resource_limits(limits)
@@ -297,10 +294,7 @@ mod integration_tests_jwt_source {
     #[ignore = "requires running SPIFFE Workload API"]
     async fn test_unlimited_resource_limits() {
         // Test with unlimited limits
-        let limits = ResourceLimits {
-            max_bundles: None,
-            max_bundle_jwks_bytes: None,
-        };
+        let limits = ResourceLimits::unlimited();
 
         let source = JwtSourceBuilder::new()
             .resource_limits(limits)

--- a/spiffe/tests/x509_source.rs
+++ b/spiffe/tests/x509_source.rs
@@ -321,11 +321,7 @@ mod integration_tests_x509_source {
     #[ignore = "requires running SPIFFE Workload API"]
     async fn test_resource_limits() {
         // Test with very restrictive limits (should still work if actual values are below limits)
-        let limits = ResourceLimits {
-            max_svids: Some(10),
-            max_bundles: Some(10),
-            max_bundle_der_bytes: Some(1024 * 1024), // 1MB
-        };
+        let limits = ResourceLimits::new(Some(10), Some(10), Some(1024 * 1024));
 
         let source = X509SourceBuilder::new()
             .resource_limits(limits)
@@ -345,11 +341,7 @@ mod integration_tests_x509_source {
     #[ignore = "requires running SPIFFE Workload API"]
     async fn test_unlimited_resource_limits() {
         // Test with unlimited limits
-        let limits = ResourceLimits {
-            max_svids: None,
-            max_bundles: None,
-            max_bundle_der_bytes: None,
-        };
+        let limits = ResourceLimits::unlimited();
 
         let source = X509SourceBuilder::new()
             .resource_limits(limits)


### PR DESCRIPTION
## Context

Source configuration structs are good candidates for future additive fields, but today
downstream struct-literal construction would make such additions breaking.

## Changes
- Mark `X509ResourceLimits` and `JwtResourceLimits` as non-exhaustive.
- Add `X509ResourceLimits::new(...)` and `JwtResourceLimits::new(...)` for explicit finite or mixed limits.
- Update docs and integration tests to use `new(...)` / `unlimited()` instead of struct literals.
- Add a changelog entry.

## Security
- Advisory: N/A
- Fix: N/A; this is API future-proofing. Resource-limit defaults and enforcement behavior are unchanged.

## Compatibility
- MSRV: unchanged
- Breaking changes: downstream callers can no longer construct `X509ResourceLimits` or `JwtResourceLimits` with struct literals.
- Affected crates/features (if applicable): `spiffe` with `x509-source` and/or `jwt-source`

## Testing
- `cargo fmt --all`
- `cargo test -p spiffe --no-default-features --features "x509-source,jwt-source,jwt-verify-rust-crypto" --doc`
- `cargo test -p spiffe --no-default-features --features "x509-source,jwt-source,jwt-verify-rust-crypto"`
- `cargo clippy -p spiffe --no-default-features --features "x509-source,jwt-source,jwt-verify-rust-crypto" --all-targets -- -D warnings`

## Release notes
- **Source limits:** Marked `X509ResourceLimits` and `JwtResourceLimits`; construct resource limits with `new`, `default`, `default_limits`, or `unlimited`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxlambrecht/rust-spiffe/359)
<!-- Reviewable:end -->
