### PR TITLE
feat(jwt-source)!: rename get_jwt_svid accessors to fetch_*

### DIFF
--- a/spiffe/CHANGELOG.md
+++ b/spiffe/CHANGELOG.md
@@ -8,6 +8,7 @@
 - **Features:** Removed the redundant `workload-api-full` feature; use `workload-api` instead.
 - **Re-exports:** Dropped the unprefixed `ReconnectConfig` and `ResourceLimits` re-exports at the crate root; use the `X509`/`Jwt`-prefixed aliases (`X509ReconnectConfig`, `X509ResourceLimits`, `JwtReconnectConfig`, `JwtResourceLimits`) or the `x509_source`/`jwt_source` module paths.
 - **Source limits:** Marked `X509ResourceLimits` and `JwtResourceLimits`; construct resource limits with `new`, `default`, `default_limits`, or `unlimited`.
+- **JwtSource:** Renamed `get_jwt_svid` to `fetch_jwt_svid` and `get_jwt_svid_with_id` to `fetch_jwt_svid_with_id`.
 
 ## [0.15.1] - 2026-05-11
 

--- a/spiffe/README.md
+++ b/spiffe/README.md
@@ -132,11 +132,11 @@ use spiffe::{TrustDomain, JwtSource};
 let source = JwtSource::new().await?;
 
 // Fetch JWT SVID for specific audiences
-let jwt_svid = source.get_jwt_svid(&["service-a", "service-b"]).await?;
+let jwt_svid = source.fetch_jwt_svid(&["service-a", "service-b"]).await?;
 
 // Fetch JWT SVID for a specific SPIFFE ID
 let spiffe_id = "spiffe://example.org/my-service".parse()?;
-let jwt_svid = source.get_jwt_svid_with_id(&["audience"], Some(&spiffe_id)).await?;
+let jwt_svid = source.fetch_jwt_svid_with_id(&["audience"], Some(&spiffe_id)).await?;
 
 // Bundle for a trust domain
 let trust_domain = TrustDomain::new("example.org")?;
@@ -177,7 +177,7 @@ use spiffe::JwtSource;
 let source = JwtSource::new().await?;
 
 // Fetch JWT SVID
-let jwt_svid = source.get_jwt_svid(&["audience1", "audience2"]).await?;
+let jwt_svid = source.fetch_jwt_svid(&["audience1", "audience2"]).await?;
 ```
 
 See the [`JwtSource`](#jwtsource-recommended) section above for more details.

--- a/spiffe/src/jwt_source/builder.rs
+++ b/spiffe/src/jwt_source/builder.rs
@@ -415,8 +415,8 @@ impl JwtSourceBuilder {
     /// The initial bundle set may contain no JWT signing authorities; in that case,
     /// [`JwtSource::is_healthy`] may report `false` until usable authorities arrive.
     /// The on-demand JWT SVID client is created lazily on the first
-    /// [`JwtSource::get_jwt_svid`] call, so client-creation failures for on-demand
-    /// JWT SVID fetching are reported by `get_jwt_svid` rather than `build`.
+    /// [`JwtSource::fetch_jwt_svid`] call, so client-creation failures for on-demand
+    /// JWT SVID fetching are reported by `fetch_jwt_svid` rather than `build`.
     ///
     /// # Errors
     ///

--- a/spiffe/src/jwt_source/mod.rs
+++ b/spiffe/src/jwt_source/mod.rs
@@ -9,7 +9,7 @@
 //! Workload API for bundle rotations. Transient failures are handled by reconnecting with backoff.
 //!
 //! Unlike X.509 SVIDs which are streamed continuously, JWT SVIDs are fetched on-demand with
-//! specific audiences. Use [`JwtSource::get_jwt_svid`] to fetch JWT SVIDs as needed.
+//! specific audiences. Use [`JwtSource::fetch_jwt_svid`] to fetch JWT SVIDs as needed.
 //!
 //! Use [`JwtSource::updated`] to subscribe to bundle change notifications, and [`JwtSource::shutdown`]
 //! to stop background tasks.
@@ -28,7 +28,7 @@
 //! let source = JwtSource::new().await?;
 //!
 //! // Fetch a JWT SVID for a specific audience
-//! let jwt_svid = source.get_jwt_svid(&["service-a", "service-b"]).await?;
+//! let jwt_svid = source.fetch_jwt_svid(&["service-a", "service-b"]).await?;
 //!
 //! let td = TrustDomain::new("example.org")?;
 //! let bundle = source

--- a/spiffe/src/jwt_source/source.rs
+++ b/spiffe/src/jwt_source/source.rs
@@ -145,7 +145,7 @@ impl JwtSourceUpdates {
 /// - Validates resource limits before publishing updates
 ///
 /// Unlike X.509 SVIDs which are streamed continuously, JWT SVIDs are fetched on-demand
-/// with specific audiences. Use [`JwtSource::get_jwt_svid`] to fetch JWT SVIDs as needed.
+/// with specific audiences. Use [`JwtSource::fetch_jwt_svid`] to fetch JWT SVIDs as needed.
 ///
 /// Use [`JwtSource::shutdown`] or [`JwtSource::shutdown_configured`] to stop background tasks.
 ///
@@ -460,18 +460,18 @@ impl JwtSource {
     /// let source = JwtSource::new().await?;
     ///
     /// // Fetch a JWT SVID for specific audiences
-    /// let jwt_svid = source.get_jwt_svid(&["service-a", "service-b"]).await?;
+    /// let jwt_svid = source.fetch_jwt_svid(&["service-a", "service-b"]).await?;
     /// println!("SPIFFE ID: {}", jwt_svid.spiffe_id());
     ///
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn get_jwt_svid<I>(&self, audience: I) -> Result<JwtSvid, JwtSourceError>
+    pub async fn fetch_jwt_svid<I>(&self, audience: I) -> Result<JwtSvid, JwtSourceError>
     where
         I: IntoIterator,
         I::Item: AsRef<str>,
     {
-        self.get_jwt_svid_with_id(audience, None).await
+        self.fetch_jwt_svid_with_id(audience, None).await
     }
 
     /// Fetches a JWT SVID for the given audience and optional SPIFFE ID.
@@ -495,10 +495,10 @@ impl JwtSource {
     ///
     /// // Fetch for a specific SPIFFE ID
     /// let spiffe_id = "spiffe://example.org/myservice".parse()?;
-    /// let jwt_svid = source.get_jwt_svid_with_id(&["service-a"], Some(&spiffe_id)).await?;
+    /// let jwt_svid = source.fetch_jwt_svid_with_id(&["service-a"], Some(&spiffe_id)).await?;
     /// # Ok(())
     /// # }
-    pub async fn get_jwt_svid_with_id<I>(
+    pub async fn fetch_jwt_svid_with_id<I>(
         &self,
         audience: I,
         spiffe_id: Option<&SpiffeId>,
@@ -1068,13 +1068,13 @@ mod tests {
         let spiffe_id = SpiffeId::new("spiffe://example.org/service").unwrap();
         let result = test_source
             .source
-            .get_jwt_svid_with_id(["aud1"], Some(&spiffe_id))
+            .fetch_jwt_svid_with_id(["aud1"], Some(&spiffe_id))
             .await;
         (result, test_source)
     }
 
     #[tokio::test]
-    async fn get_jwt_svid_does_not_retry_permission_denied() {
+    async fn fetch_jwt_svid_does_not_retry_permission_denied() {
         let (result, test_source) =
             fetch_test_result(vec![FetchOutcome::PermissionDenied("not allowed")]).await;
 
@@ -1089,7 +1089,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_jwt_svid_does_not_retry_no_identity_issued() {
+    async fn fetch_jwt_svid_does_not_retry_no_identity_issued() {
         let (result, test_source) = fetch_test_result(vec![FetchOutcome::NoIdentityIssued]).await;
 
         assert!(matches!(
@@ -1103,7 +1103,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_jwt_svid_does_not_retry_hint_not_found() {
+    async fn fetch_jwt_svid_does_not_retry_hint_not_found() {
         let (result, test_source) =
             fetch_test_result(vec![FetchOutcome::HintNotFound("external")]).await;
 
@@ -1118,7 +1118,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_jwt_svid_does_not_retry_jwt_parse_error() {
+    async fn fetch_jwt_svid_does_not_retry_jwt_parse_error() {
         let (result, test_source) = fetch_test_result(vec![FetchOutcome::InvalidJwt]).await;
 
         assert!(matches!(
@@ -1130,7 +1130,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_jwt_svid_retries_once_on_unavailable() {
+    async fn fetch_jwt_svid_retries_once_on_unavailable() {
         let (result, test_source) =
             fetch_test_result(vec![FetchOutcome::Unavailable, FetchOutcome::Ok]).await;
 
@@ -1140,7 +1140,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_jwt_svid_returns_second_failure_after_retry() {
+    async fn fetch_jwt_svid_returns_second_failure_after_retry() {
         let (result, test_source) = fetch_test_result(vec![
             FetchOutcome::Unavailable,
             FetchOutcome::PermissionDenied("still denied"),

--- a/spiffe/src/lib.rs
+++ b/spiffe/src/lib.rs
@@ -31,7 +31,7 @@
 //! use spiffe::{bundle::BundleSource, TrustDomain, JwtSource};
 //!
 //! let source = JwtSource::new().await?;
-//! let _jwt_svid = source.get_jwt_svid(&["service-a", "service-b"]).await?;
+//! let _jwt_svid = source.fetch_jwt_svid(&["service-a", "service-b"]).await?;
 //! let trust_domain = TrustDomain::try_from("example.org")?;
 //! let _bundle = source
 //!     .bundle_for_trust_domain(&trust_domain)?
@@ -124,7 +124,7 @@
 //! use spiffe::{bundle::BundleSource, TrustDomain, JwtSource};
 //!
 //! let source = JwtSource::new().await?;
-//! let _jwt_svid = source.get_jwt_svid(&["service-a", "service-b"]).await?;
+//! let _jwt_svid = source.fetch_jwt_svid(&["service-a", "service-b"]).await?;
 //! let trust_domain = TrustDomain::try_from("example.org")?;
 //! let _bundle = source
 //!     .bundle_for_trust_domain(&trust_domain)?

--- a/spiffe/tests/jwt_source.rs
+++ b/spiffe/tests/jwt_source.rs
@@ -166,11 +166,11 @@ mod integration_tests_jwt_source {
 
     #[tokio::test]
     #[ignore = "requires running SPIFFE Workload API"]
-    async fn test_get_jwt_svid() {
+    async fn test_fetch_jwt_svid() {
         let source = get_source().await;
         let audience = vec!["test-audience".to_string()];
         let svid = source
-            .get_jwt_svid(&audience)
+            .fetch_jwt_svid(&audience)
             .await
             .expect("Failed to get JWT SVID");
 
@@ -185,11 +185,11 @@ mod integration_tests_jwt_source {
 
     #[tokio::test]
     #[ignore = "requires running SPIFFE Workload API"]
-    async fn test_get_jwt_svid_with_id() {
+    async fn test_fetch_jwt_svid_with_id() {
         let source = get_source().await;
         let audience = vec!["test-audience".to_string()];
         let svid = source
-            .get_jwt_svid_with_id(&audience, Some(&spiffe_id_1()))
+            .fetch_jwt_svid_with_id(&audience, Some(&spiffe_id_1()))
             .await
             .expect("Failed to get JWT SVID with ID");
 
@@ -596,32 +596,35 @@ mod integration_tests_jwt_source {
 
     #[tokio::test]
     #[ignore = "requires running SPIFFE Workload API"]
-    async fn test_get_jwt_svid_after_shutdown() {
+    async fn test_fetch_jwt_svid_after_shutdown() {
         let source = get_source().await;
         source.shutdown().await;
 
         let audience = vec!["test-audience".to_string()];
-        let result = source.get_jwt_svid(&audience).await;
+        let result = source.fetch_jwt_svid(&audience).await;
 
         // Should fail after shutdown
-        assert!(result.is_err(), "get_jwt_svid() should fail after shutdown");
+        assert!(
+            result.is_err(),
+            "fetch_jwt_svid() should fail after shutdown"
+        );
     }
 
     #[tokio::test]
     #[ignore = "requires running SPIFFE Workload API"]
-    async fn test_get_jwt_svid_with_id_after_shutdown() {
+    async fn test_fetch_jwt_svid_with_id_after_shutdown() {
         let source = get_source().await;
         source.shutdown().await;
 
         let audience = vec!["test-audience".to_string()];
         let result = source
-            .get_jwt_svid_with_id(&audience, Some(&spiffe_id_1()))
+            .fetch_jwt_svid_with_id(&audience, Some(&spiffe_id_1()))
             .await;
 
         // Should fail after shutdown
         assert!(
             result.is_err(),
-            "get_jwt_svid_with_id() should fail after shutdown"
+            "fetch_jwt_svid_with_id() should fail after shutdown"
         );
     }
 }


### PR DESCRIPTION
## Context
Maintenance for the 0.16.0 breaking release. The `JwtSource` SVID accessors used
a `get_` prefix, which is non-idiomatic in Rust (C-GETTER) and inconsistent with
the cached `X509Source::svid()` accessor.

## Changes
- Rename `JwtSource::get_jwt_svid` to `fetch_jwt_svid`.
- Rename `JwtSource::get_jwt_svid_with_id` to `fetch_jwt_svid_with_id`.
- Update doc comments, intra-doc links, examples, README, and tests.
- Add a changelog entry.

Naming convention applied across the sources: cached, synchronous reads stay as
nouns (`X509Source::svid()` / `try_svid()`); on-demand Workload API I/O uses the
`fetch_` verb. This also matches the internal `client.fetch_jwt_svid(...)` and the
sibling libraries (go-spiffe `FetchJWTSVID`, py-spiffe `fetch_jwt_svid`).

## Security
- Advisory: N/A
- Fix: N/A; this is an API naming change. Fetch behavior, retry semantics, and error handling are unchanged.

## Compatibility
- MSRV: unchanged
- Breaking changes: `JwtSource::get_jwt_svid` and `get_jwt_svid_with_id` are renamed to `fetch_jwt_svid` and `fetch_jwt_svid_with_id`. Callers must update to the new names.
- Affected crates/features (if applicable): `spiffe` with `jwt-source`

## Testing
- `cargo fmt --all`
- `cargo test -p spiffe --no-default-features --features "x509-source,jwt-source,jwt-verify-rust-crypto" --doc`
- `cargo test -p spiffe --no-default-features --features "x509-source,jwt-source,jwt-verify-rust-crypto"`
- `cargo clippy -p spiffe --no-default-features --features "x509-source,jwt-source,jwt-verify-rust-crypto" --all-targets -- -D warnings`

## Release notes
- **JwtSource:** Renamed `get_jwt_svid` to `fetch_jwt_svid` and `get_jwt_svid_with_id`
  to `fetch_jwt_svid_with_id`, dropping the non-idiomatic `get_` prefix and matching
  the `fetch_` naming used by sibling SPIFFE libraries.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxlambrecht/rust-spiffe/360)
<!-- Reviewable:end -->
