### PR TITLE
feat(api): re-export common certificate and source types

### DIFF
--- a/spiffe/CHANGELOG.md
+++ b/spiffe/CHANGELOG.md
@@ -10,6 +10,11 @@
 - **Source limits:** Marked `X509ResourceLimits` and `JwtResourceLimits`; construct resource limits with `new`, `default`, `default_limits`, or `unlimited`.
 - **JwtSource:** Renamed `get_jwt_svid` to `fetch_jwt_svid` and `get_jwt_svid_with_id` to `fetch_jwt_svid_with_id`.
 
+### Added
+
+- **Re-exports:** Re-exported `Certificate` and `PrivateKey` at the crate root (previously only available under `spiffe::cert`).
+- **Re-exports:** Re-exported the `BundleSource` and `SvidSource` traits at the crate root, so the trait no longer needs to be imported from `spiffe::bundle` / `spiffe::svid`.
+
 ## [0.15.1] - 2026-05-11
 
 ### Fixed

--- a/spiffe/README.md
+++ b/spiffe/README.md
@@ -389,7 +389,7 @@ Note: `nbf`, `iat`, and `iss` claims are not validated. See the
 [`JwtSvid::parse_and_validate`] documentation for complete details.
 
 ```rust
-use spiffe::{bundle::BundleSource, JwtBundle, JwtSvid};
+use spiffe::{BundleSource, JwtBundle, JwtSvid};
 
 fn validate_token<B: BundleSource<Item = JwtBundle>>(
     token: &str,

--- a/spiffe/src/jwt_source/mod.rs
+++ b/spiffe/src/jwt_source/mod.rs
@@ -23,7 +23,7 @@
 //! # #[cfg(feature = "jwt-source")]
 //! # async fn example() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 //! use spiffe::{TrustDomain, JwtSource};
-//! use spiffe::bundle::BundleSource;
+//! use spiffe::BundleSource;
 //!
 //! let source = JwtSource::new().await?;
 //!

--- a/spiffe/src/lib.rs
+++ b/spiffe/src/lib.rs
@@ -11,7 +11,7 @@
 //! ```no_run
 //! # #[cfg(feature = "x509-source")]
 //! # async fn example() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-//! use spiffe::{bundle::BundleSource, TrustDomain, X509Source};
+//! use spiffe::{BundleSource, TrustDomain, X509Source};
 //!
 //! let source = X509Source::new().await?;
 //! let _svid = source.svid()?;
@@ -28,7 +28,7 @@
 //! ```no_run
 //! # #[cfg(feature = "jwt-source")]
 //! # async fn example() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-//! use spiffe::{bundle::BundleSource, TrustDomain, JwtSource};
+//! use spiffe::{BundleSource, TrustDomain, JwtSource};
 //!
 //! let source = JwtSource::new().await?;
 //! let _jwt_svid = source.fetch_jwt_svid(&["service-a", "service-b"]).await?;
@@ -97,42 +97,6 @@
 //! - For direct Workload API usage, use `workload-api-x509` or `workload-api-jwt` when you only need one,
 //!   and `workload-api` when you need both.
 //!
-//! ## X.509
-//!
-//! ```no_run
-//! # #[cfg(feature = "x509-source")]
-//! # async fn example() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-//! use spiffe::{TrustDomain, X509Source};
-//! use spiffe::bundle::BundleSource;
-//!
-//! let source = X509Source::new().await?;
-//! let _svid = source.svid()?;
-//! let trust_domain = TrustDomain::try_from("example.org")?;
-//! let _bundle = source
-//!     .bundle_for_trust_domain(&trust_domain)?
-//!     .ok_or("missing bundle")?;
-//!
-//! # Ok(())
-//! # }
-//! ```
-//!
-//! For JWT-based workloads, use [`JwtSource`] (requires the `jwt-source` feature):
-//!
-//! ```no_run
-//! # #[cfg(feature = "jwt-source")]
-//! # async fn example() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-//! use spiffe::{bundle::BundleSource, TrustDomain, JwtSource};
-//!
-//! let source = JwtSource::new().await?;
-//! let _jwt_svid = source.fetch_jwt_svid(&["service-a", "service-b"]).await?;
-//! let trust_domain = TrustDomain::try_from("example.org")?;
-//! let _bundle = source
-//!     .bundle_for_trust_domain(&trust_domain)?
-//!     .ok_or("missing bundle")?;
-//! # Ok(())
-//! # }
-//! ```
-//!
 //! For advanced configuration, see the [`x509_source`] and [`jwt_source`] modules.
 
 // "logging" and "tracing" can both be enabled, causing logging to be unused.
@@ -192,6 +156,14 @@ pub use crate::svid::x509::{X509Svid, X509SvidError};
 pub use crate::bundle::jwt::{JwtBundle, JwtBundleError, JwtBundleSet};
 #[cfg(feature = "x509")]
 pub use crate::bundle::x509::{X509Bundle, X509BundleError, X509BundleSet};
+
+// Certificate and private key types
+#[cfg(feature = "x509")]
+pub use crate::cert::{Certificate, PrivateKey};
+
+// Source traits
+pub use crate::bundle::BundleSource;
+pub use crate::svid::SvidSource;
 
 // Workload API - Common types
 //

--- a/spiffe/src/x509_source/mod.rs
+++ b/spiffe/src/x509_source/mod.rs
@@ -23,7 +23,7 @@
 //! # #[cfg(feature = "x509-source")]
 //! # async fn example() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 //! use spiffe::{TrustDomain, X509Source};
-//! use spiffe::bundle::BundleSource;
+//! use spiffe::BundleSource;
 //!
 //! let source = X509Source::new().await?;
 //!

--- a/spiffe/tests/jwt_source.rs
+++ b/spiffe/tests/jwt_source.rs
@@ -26,10 +26,10 @@
     reason = "https://github.com/rust-lang/rust-clippy/issues/11119"
 )]
 mod integration_tests_jwt_source {
-    use spiffe::bundle::BundleSource as _;
     use spiffe::jwt_source::JwtSourceBuilder;
     use spiffe::jwt_source::{JwtSource, MetricsErrorKind, MetricsRecorder, ResourceLimits};
     use spiffe::workload_api::error::WorkloadApiError;
+    use spiffe::BundleSource as _;
     use spiffe::{JwtBundle, SpiffeId, TrustDomain, WorkloadApiClient};
     use std::collections::HashMap;
 

--- a/spiffe/tests/workload_api_client.rs
+++ b/spiffe/tests/workload_api_client.rs
@@ -6,7 +6,7 @@
 #[cfg(feature = "workload-api")]
 mod integration_tests_workload_api_client {
     use futures::StreamExt as _;
-    use spiffe::bundle::BundleSource as _;
+    use spiffe::BundleSource as _;
     use spiffe::{SpiffeId, TrustDomain, WorkloadApiClient};
     use std::sync::LazyLock;
 

--- a/spiffe/tests/x509_source.rs
+++ b/spiffe/tests/x509_source.rs
@@ -25,12 +25,12 @@
     reason = "https://github.com/rust-lang/rust-clippy/issues/11119"
 )]
 mod integration_tests_x509_source {
-    use spiffe::bundle::BundleSource as _;
     use spiffe::workload_api::error::WorkloadApiError;
     use spiffe::x509_source::X509SourceBuilder;
     use spiffe::x509_source::{
         MetricsErrorKind, MetricsRecorder, ResourceLimits, SvidPicker, X509Source,
     };
+    use spiffe::BundleSource as _;
     use spiffe::{SpiffeId, TrustDomain, WorkloadApiClient, X509Bundle, X509Svid};
     use std::collections::HashMap;
     use std::future::Future;


### PR DESCRIPTION
## Context
Maintenance for the 0.16.0 release. Some common public API types appeared in
method signatures but were only available through module paths, which made
imports more verbose than the rest of the crate root API.

## Changes
- Re-export `Certificate` and `PrivateKey` at the crate root when `x509` is enabled.
- Re-export the `BundleSource` and `SvidSource` traits at the crate root.
- Update docs, examples, tests, and README imports to use the shorter root paths.
- Remove duplicated crate-level quick-start examples from `lib.rs`.
- Add changelog entries under `Added`.

## Security
- Advisory: N/A
- Fix: N/A; this is an additive API ergonomics change. Certificate/private-key validation and source behavior are unchanged.

## Compatibility
- MSRV: unchanged
- Breaking changes: none
- Affected crates/features (if applicable): `spiffe`; `Certificate`/`PrivateKey` root re-exports are gated on `x509`

## Testing
- `cargo fmt --all`
- `cargo test -p spiffe --no-default-features --features "x509-source,jwt-source,jwt-verify-rust-crypto" --doc`
- `cargo test -p spiffe --no-default-features --features "x509-source,jwt-source,jwt-verify-rust-crypto"`
- `cargo clippy -p spiffe --no-default-features --features "x509-source,jwt-source,jwt-verify-rust-crypto" --all-targets -- -D warnings`
- `cargo build -p spiffe --no-default-features --features "jwt"`
- `cargo build -p spiffe --no-default-features --features "x509"`
- `cargo build -p spiffe --no-default-features`

## Release notes
- **Re-exports:** Re-exported `Certificate` and `PrivateKey` at the crate root (previously only available under `spiffe::cert`).
- **Re-exports:** Re-exported the `BundleSource` and `SvidSource` traits at the crate root, so the trait no longer needs to be imported from `spiffe::bundle` / `spiffe::svid`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxlambrecht/rust-spiffe/361)
<!-- Reviewable:end -->
