### PR TITLE
feat(source)!: make reconnect config non-exhaustive

### DIFF
--- a/spiffe/CHANGELOG.md
+++ b/spiffe/CHANGELOG.md
@@ -9,6 +9,7 @@
 - **Re-exports:** Dropped the unprefixed `ReconnectConfig` and `ResourceLimits` re-exports at the crate root; use the `X509`/`Jwt`-prefixed aliases (`X509ReconnectConfig`, `X509ResourceLimits`, `JwtReconnectConfig`, `JwtResourceLimits`) or the `x509_source`/`jwt_source` module paths.
 - **Source limits:** Marked `X509ResourceLimits` and `JwtResourceLimits`; construct resource limits with `new`, `default`, `default_limits`, or `unlimited`.
 - **JwtSource:** Renamed `get_jwt_svid` to `fetch_jwt_svid` and `get_jwt_svid_with_id` to `fetch_jwt_svid_with_id`.
+- **Source reconnect config:** Marked `X509ReconnectConfig` and `JwtReconnectConfig` as non-exhaustive; construct them with `ReconnectConfig::new(min_backoff, max_backoff)`, `default`, or the builder's `reconnect_backoff(...)`.
 
 ### Added
 

--- a/spiffe/src/jwt_source/builder.rs
+++ b/spiffe/src/jwt_source/builder.rs
@@ -14,6 +14,7 @@ use std::time::Duration;
 /// to prevent synchronized reconnect storms in high-concurrency scenarios.
 ///
 /// If `min_backoff > max_backoff`, they will be swapped to ensure valid configuration.
+#[non_exhaustive]
 #[derive(Clone, Copy, Debug)]
 pub struct ReconnectConfig {
     /// Initial delay before retrying.
@@ -32,6 +33,18 @@ impl Default for ReconnectConfig {
 }
 
 impl ReconnectConfig {
+    /// Creates a `ReconnectConfig` with explicit backoff bounds.
+    ///
+    /// `min_backoff` is the initial retry delay and `max_backoff` is the cap. If
+    /// `min_backoff > max_backoff`, the values are swapped when the source is built.
+    #[must_use]
+    pub const fn new(min_backoff: Duration, max_backoff: Duration) -> Self {
+        Self {
+            min_backoff,
+            max_backoff,
+        }
+    }
+
     /// Normalizes the configuration to ensure `min_backoff <= max_backoff`.
     ///
     /// If `min_backoff > max_backoff`, they are swapped. This ensures valid
@@ -297,10 +310,7 @@ impl JwtSourceBuilder {
     pub const fn reconnect_backoff(mut self, min_backoff: Duration, max_backoff: Duration) -> Self {
         // Normalization happens at the authoritative boundary in JwtSource::build_with().
         // This setter stores the raw values; normalization ensures min <= max.
-        self.reconnect = ReconnectConfig {
-            min_backoff,
-            max_backoff,
-        };
+        self.reconnect = ReconnectConfig::new(min_backoff, max_backoff);
         self
     }
 

--- a/spiffe/src/x509_source/builder.rs
+++ b/spiffe/src/x509_source/builder.rs
@@ -14,6 +14,7 @@ use std::time::Duration;
 /// to prevent synchronized reconnect storms in high-concurrency scenarios.
 ///
 /// If `min_backoff > max_backoff`, they will be swapped to ensure valid configuration.
+#[non_exhaustive]
 #[derive(Clone, Copy, Debug)]
 pub struct ReconnectConfig {
     /// Initial delay before retrying.
@@ -32,6 +33,18 @@ impl Default for ReconnectConfig {
 }
 
 impl ReconnectConfig {
+    /// Creates a `ReconnectConfig` with explicit backoff bounds.
+    ///
+    /// `min_backoff` is the initial retry delay and `max_backoff` is the cap. If
+    /// `min_backoff > max_backoff`, the values are swapped when the source is built.
+    #[must_use]
+    pub const fn new(min_backoff: Duration, max_backoff: Duration) -> Self {
+        Self {
+            min_backoff,
+            max_backoff,
+        }
+    }
+
     /// Normalizes the configuration to ensure `min_backoff <= max_backoff`.
     ///
     /// If `min_backoff > max_backoff`, they are swapped. This ensures valid
@@ -356,10 +369,7 @@ impl X509SourceBuilder {
     pub const fn reconnect_backoff(mut self, min_backoff: Duration, max_backoff: Duration) -> Self {
         // Normalization happens at the authoritative boundary in X509Source::new_with().
         // This setter stores the raw values; normalization ensures min <= max.
-        self.reconnect = ReconnectConfig {
-            min_backoff,
-            max_backoff,
-        };
+        self.reconnect = ReconnectConfig::new(min_backoff, max_backoff);
         self
     }
 


### PR DESCRIPTION
## Context
Maintenance for the 0.16.0 breaking release, and a direct follow-up to the
resource-limits change. `X509ReconnectConfig` / `JwtReconnectConfig` are good
candidates for future additive fields, but downstream struct-literal construction
would make such additions breaking.

## Changes
- Mark `X509ReconnectConfig` and `JwtReconnectConfig` as non-exhaustive.
- Add `ReconnectConfig::new(min_backoff, max_backoff)`.
- Route the builders' `reconnect_backoff(...)` setter through `new(...)`.
- Add a changelog entry.

## Security
- Advisory: N/A
- Fix: N/A; this is API future-proofing. Backoff defaults, normalization (`min <= max`), and reconnect behavior are unchanged.

## Compatibility
- MSRV: unchanged
- Breaking changes: downstream callers can no longer construct `X509ReconnectConfig` or `JwtReconnectConfig` with struct literals. Use `ReconnectConfig::new`, `default`, or the builder's `reconnect_backoff(...)`.
- Affected crates/features (if applicable): `spiffe` with `x509-source` and/or `jwt-source`

## Testing
- `cargo fmt --all`
- `cargo test -p spiffe --no-default-features --features "x509-source,jwt-source,jwt-verify-rust-crypto"`
- `cargo test -p spiffe --no-default-features --features "x509-source,jwt-source,jwt-verify-rust-crypto" --doc`
- `cargo clippy -p spiffe --no-default-features --features "x509-source,jwt-source,jwt-verify-rust-crypto" --all-targets -- -D warnings`

## Release notes
- **Source reconnect config:** Marked `X509ReconnectConfig` and `JwtReconnectConfig`
  as non-exhaustive; construct them with `ReconnectConfig::new(min_backoff, max_backoff)`,
  `default`, or the builder's `reconnect_backoff(...)`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxlambrecht/rust-spiffe/362)
<!-- Reviewable:end -->
