### PR TITLE
chore(release): spiffe 0.16.0 and bump dependent crates

### DIFF
--- a/spiffe-rustls-grpc-examples/Cargo.toml
+++ b/spiffe-rustls-grpc-examples/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-spiffe = { version = "0.15", path = "../spiffe", features = ["x509-source"] }
+spiffe = { version = "0.16", path = "../spiffe", features = ["x509-source"] }
 spiffe-rustls = { path = "../spiffe-rustls", features = ["ring"] }
 
 # gRPC stack

--- a/spiffe-rustls-tokio/CHANGELOG.md
+++ b/spiffe-rustls-tokio/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.4.0] – 2026-06-08
+
+### Breaking changes
+
+- Bumped the `spiffe` dependency from `0.15` to `0.16`. `spiffe-rustls-tokio` exposes `spiffe::SpiffeId` through `PeerIdentity`, so downstream users must use compatible `spiffe` `0.16` types.
+- Updated examples and development dependency to `spiffe-rustls` `0.7`.
+
 ## [0.3.0] – 2026-05-08
 
 ### Breaking changes

--- a/spiffe-rustls-tokio/Cargo.toml
+++ b/spiffe-rustls-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spiffe-rustls-tokio"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -19,7 +19,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dependencies]
-spiffe = { version = "0.15", path = "../spiffe", features = ["x509-source"] }
+spiffe = { version = "0.16", path = "../spiffe", features = ["x509-source"] }
 tokio = { version = "1", default-features = false, features = ["net", "rt"] }
 tokio-rustls = { version = "0.26", default-features = false }
 rustls = { version = "0.23", default-features = false, features = ["std"] }
@@ -28,7 +28,7 @@ thiserror = "2"
 [dev-dependencies]
 anyhow = "1"
 env_logger = "0.11"
-spiffe-rustls = { version = "0.6", path = "../spiffe-rustls" }
+spiffe-rustls = { version = "0.7", path = "../spiffe-rustls" }
 tokio = { version = "1", default-features = false, features = [
     "rt-multi-thread",
     "signal",

--- a/spiffe-rustls/CHANGELOG.md
+++ b/spiffe-rustls/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.7.0] - 2026-06-08
+
+### Breaking changes
+
+- Bumped the `spiffe` dependency from `0.15` to `0.16`. Because `spiffe-rustls` exposes `spiffe` types in its public API (`SpiffeId`, `TrustDomain`, and `X509Source`), downstream users must use compatible `spiffe` `0.16` types.
+
 ## [0.6.2] - 2026-06-07
 
 ### Security

--- a/spiffe-rustls/Cargo.toml
+++ b/spiffe-rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spiffe-rustls"
-version = "0.6.2"
+version = "0.7.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -19,7 +19,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dependencies]
-spiffe = { version = "0.15", path = "../spiffe", features = ["x509-source"] }
+spiffe = { version = "0.16", path = "../spiffe", features = ["x509-source"] }
 rustls = { version = "0.23", default-features = false, features = ["std"] }
 tokio = { version = "1", default-features = false, features = ["rt", "sync"] }
 tokio-util = "0.7"

--- a/spiffe/CHANGELOG.md
+++ b/spiffe/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Changelog
 
-## [Unreleased]
+## [0.16.0] - 2026-06-08
 
 ### Breaking changes
 
 - **Features:** `x509-source` now enables only `workload-api-x509`, and `jwt-source` only `workload-api-jwt`, so each source no longer pulls in the other SVID type's parsing dependencies.
 - **Features:** Removed the redundant `workload-api-full` feature; use `workload-api` instead.
 - **Re-exports:** Dropped the unprefixed `ReconnectConfig` and `ResourceLimits` re-exports at the crate root; use the `X509`/`Jwt`-prefixed aliases (`X509ReconnectConfig`, `X509ResourceLimits`, `JwtReconnectConfig`, `JwtResourceLimits`) or the `x509_source`/`jwt_source` module paths.
-- **Source limits:** Marked `X509ResourceLimits` and `JwtResourceLimits`; construct resource limits with `new`, `default`, `default_limits`, or `unlimited`.
+- **Source limits:** Marked `X509ResourceLimits` and `JwtResourceLimits` as non-exhaustive; construct resource limits with `new`, `default`, `default_limits`, or `unlimited`.
 - **JwtSource:** Renamed `get_jwt_svid` to `fetch_jwt_svid` and `get_jwt_svid_with_id` to `fetch_jwt_svid_with_id`.
 - **Source reconnect config:** Marked `X509ReconnectConfig` and `JwtReconnectConfig` as non-exhaustive; construct them with `ReconnectConfig::new(min_backoff, max_backoff)`, `default`, or the builder's `reconnect_backoff(...)`.
 

--- a/spiffe/Cargo.toml
+++ b/spiffe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spiffe"
-version = "0.15.1"
+version = "0.16.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/spire-api/CHANGELOG.md
+++ b/spire-api/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.8.0] – 2026-06-08
+
+### Breaking changes
+
+- Bumped the `spiffe` dependency from `0.15` to `0.16`. `spire-api` exposes `spiffe` types in its public API, so downstream users must use compatible `spiffe` `0.16` types.
+
 ## [0.7.0] – 2026-05-08
 
 ### Breaking changes

--- a/spire-api/Cargo.toml
+++ b/spire-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spire-api"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -21,7 +21,7 @@ workspace = true
 [dependencies]
 futures = { version = "0.3", default-features = false }
 prost = { version = "0.14", default-features = false }
-spiffe = { version = "0.15", path = "../spiffe", features = ["x509", "jwt", "transport-grpc"] }
+spiffe = { version = "0.16", path = "../spiffe", features = ["x509", "jwt", "transport-grpc"] }
 thiserror = { version = "2", default-features = false }
 tonic = { version = "0.14", default-features = false, features = ["transport", "codegen"] }
 tonic-prost = { version = "0.14", default-features = false }


### PR DESCRIPTION
## Context
Cut the breaking `spiffe` 0.16.0 release and propagate the version bump to the
in-repo crates that depend on it. The 0.16.0 API changes themselves landed in
prior PRs; this PR finalizes the changelog and version metadata for publishing.

## Changes
- Bump versions:
  - `spiffe` 0.15.1 -> 0.16.0
  - `spiffe-rustls` 0.6.2 -> 0.7.0
  - `spire-api` 0.7.0 -> 0.8.0
  - `spiffe-rustls-tokio` 0.3.0 -> 0.4.0
- Update `spiffe = "0.16"` requirement in `spiffe-rustls`, `spire-api`,
  `spiffe-rustls-tokio`, and `spiffe-rustls-grpc-examples`.
- Bump `spiffe-rustls-tokio`'s `spiffe-rustls` dev-dependency `0.6 -> 0.7`.
- Add changelog entries for each bumped dependent.

## Security
- N/A (no security-relevant behavior change in this PR).

## Compatibility
- MSRV: unchanged.
- Breaking changes: `spiffe` 0.16.0 is breaking (see its changelog). Dependents
  take minor bumps because they re-export/expose `spiffe` types in their public
  APIs, so consumers must move to compatible `0.16` types.
- Affected crates: `spiffe`, `spiffe-rustls`, `spire-api`, `spiffe-rustls-tokio`,
  `spiffe-rustls-grpc-examples` (unpublished).

## Testing
Covered by CI. Verified locally with `cargo build --workspace` (clean) and
confirmed no stale `spiffe = "0.15"` / `spiffe-rustls = "0.6"` requirements remain.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxlambrecht/rust-spiffe/363)
<!-- Reviewable:end -->
