### PR TITLE
chore(release): prepare spiffe-rustls 0.8.0

### DIFF
--- a/spiffe-rustls-tokio/Cargo.toml
+++ b/spiffe-rustls-tokio/Cargo.toml
@@ -28,7 +28,7 @@ thiserror = "2"
 [dev-dependencies]
 anyhow = "1"
 env_logger = "0.11"
-spiffe-rustls = { version = "0.7", path = "../spiffe-rustls" }
+spiffe-rustls = { version = "0.8", path = "../spiffe-rustls" }
 tokio = { version = "1", default-features = false, features = [
     "rt-multi-thread",
     "signal",

--- a/spiffe-rustls/CHANGELOG.md
+++ b/spiffe-rustls/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.8.0] - 2026-07-18
 
 ### Security
 

--- a/spiffe-rustls/Cargo.toml
+++ b/spiffe-rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spiffe-rustls"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## Context
Prepare the `spiffe-rustls` 0.8.0 release. This release contains security hardening and correctness fixes for TLS material validation, verifier caching, watcher updates, and TLS session resumption defaults.

## Changes
- Bump `spiffe-rustls` crate version to `0.8.0`.
- Move `[Unreleased]` changelog entries to `[0.8.0] - 2026-07-18`.

## Security
- Advisory: none.
- Fix: hardens peer leaf validation, disables TLS session resumption by default so resumed handshakes cannot bypass re-verification, rejects mismatched SVID key/cert material earlier, and fixes watcher/verifier-cache correctness issues.

## Compatibility
- MSRV: unchanged.
- Breaking changes: no public API break.
- Behavior changes: deployments using non-conformant X.509-SVID leaf certificates, mismatched SVID key/cert material, or relying on TLS session resumption defaults may observe changed behavior.
- Affected crates/features: `spiffe-rustls`.

## Testing
Covered by CI. Locally verified before release prep with:
- `cargo test -p spiffe-rustls`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt`

## Release notes

## [0.8.0] - 2026-07-18

### Security

- Hardened rustls peer leaf validation: peer leaf certificates whose `KeyUsage` extension is missing or does not include `digitalSignature` are now rejected with `Error::InvalidLeaf`. This may affect deployments using non-conformant X.509-SVID leaf certificates.
- TLS session resumption is now disabled by default in both `mtls_server` and `mtls_client` configurations. rustls skips certificate re-verification on a resumed handshake, so a resumed session could outlive the peer SVID's expiry or bypass a bundle/authorizer change (e.g. defederation) until the cached session or ticket aged out — matching SPIRE's own mitigation ([spiffe/spire#6715](https://github.com/spiffe/spire/pull/6715)). No interop impact: peers requesting resumption simply fall back to a full handshake. Re-enable via `with_config_customizer` (client: `cfg.resumption`; server: `cfg.session_storage` and `cfg.send_tls13_tickets`).

### Added

- Re-exported `AuthorizerConfigError` at the crate root. It is the source error behind `Error::AuthorizerConfig` and was previously unnameable by downstream callers.

### Changed

- `certified_key_from_chain_and_key` now verifies the private key matches the leaf certificate's public key, failing at material-build time (`Error::CertifiedKey`) instead of later at TLS signing time. Mismatched SVID material that previously built "successfully" is now rejected.

### Fixed

- `MaterialWatcher` now subscribes to `X509Source` rotation updates before building its initial snapshot, closing a window where a rotation landing between the two could be missed until the next one.
- If the underlying `X509Source` is closed, `MaterialWatcher` now logs at `error` (previously `info`) when it freezes on its last known-good snapshot, including trust roots, until process restart.
- The per-trust-domain verifier build cache no longer risks wedging in a "building" state forever if a build panics or otherwise fails to reach its error-handling path; other handshakes waiting on that cache entry now reliably observe an error instead of hanging.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxlambrecht/rust-spiffe/372)
<!-- Reviewable:end -->
