### PR TITLE
chore(ci): update SPIRE test harness to 1.15.2

### DIFF
--- a/.github/workflows/scripts/run-spire.sh
+++ b/.github/workflows/scripts/run-spire.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Constants
-spire_version="1.14.0"
+spire_version="1.15.2"
 spire_folder="spire-${spire_version}"
 
 spire_server_log_file="/tmp/spire-server/server.log"


### PR DESCRIPTION
## Context
Maintenance update for the SPIRE version used by the CI integration test harness.

## Changes
- Updated `.github/workflows/scripts/run-spire.sh` from SPIRE `1.14.0` to `1.15.2`.

## Security
- Advisory: none
- Fix: no direct security fix; keeps CI coverage aligned with a newer SPIRE release.

## Compatibility
- MSRV: unchanged
- Breaking changes: none
- Affected crates/features: none; CI SPIRE integration harness only

## Testing
Covered by CI. Not run locally.

## Release notes
None; CI-only maintenance change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxlambrecht/rust-spiffe/375)
<!-- Reviewable:end -->
