### PR TITLE
fix(jwt): redact compact token from JwtSvid Debug

### DIFF
--- a/spiffe/CHANGELOG.md
+++ b/spiffe/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Security
+
+- **JwtSvid:** `Debug` no longer includes the compact JWT token; only the token length is shown (matching `PrivateKey` redaction).
+
 ## [0.16.1] - 2026-08-08
 
 ### Fixed

--- a/spiffe/src/svid/jwt/mod.rs
+++ b/spiffe/src/svid/jwt/mod.rs
@@ -95,7 +95,8 @@ impl JwtAlg {
 
 /// Represents a SPIFFE JWT-SVID.
 ///
-/// The serialized token is zeroized on drop.
+/// The serialized token is zeroized on drop and omitted from `Debug` output
+/// (only the token length is shown).
 ///
 /// ## Usage Patterns
 ///
@@ -207,10 +208,18 @@ impl From<std::convert::Infallible> for JwtSvidError {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Zeroize)]
+#[derive(Clone, Eq, PartialEq, Zeroize)]
 #[zeroize(drop)]
 struct Token {
     inner: String,
+}
+
+impl fmt::Debug for Token {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Token")
+            .field("len", &self.inner.len())
+            .finish()
+    }
 }
 
 impl From<&str> for Token {
@@ -618,6 +627,41 @@ mod tests {
         assert_eq!(svid.key_id(), "k1");
         assert_eq!(svid.audience(), &["aud1".to_string()]);
         assert_eq!(svid.token(), token);
+    }
+
+    #[test]
+    fn debug_redacts_compact_jwt() {
+        use base64ct::{Base64UrlUnpadded, Encoding as _};
+
+        // Use a distinctive signature segment so the redaction assertion cannot
+        // collide with unrelated Debug text (unlike mk_token's short ".sig").
+        let header = Base64UrlUnpadded::encode_string(
+            br#"{"alg":"ES256","kid":"redaction-key-id","typ":"JWT"}"#,
+        );
+        let claims = Base64UrlUnpadded::encode_string(
+            br#"{"sub":"spiffe://example.org/redaction-service","aud":"aud1","exp":4294967295}"#,
+        );
+        let token = format!("{header}.{claims}.signature-segment-must-not-leak");
+        let svid = JwtSvid::parse_insecure(&token).unwrap();
+
+        let debug = format!("{svid:?}");
+        assert!(!debug.contains(&token));
+        for segment in token.split('.') {
+            assert!(!debug.contains(segment));
+        }
+        assert!(debug.contains("spiffe://example.org/redaction-service"));
+        assert!(debug.contains("redaction-key-id"));
+    }
+
+    #[test]
+    fn token_debug_redacts_inner_value() {
+        let token = Token::from("header-segment.claims-segment.signature-segment");
+
+        let debug = format!("{token:?}");
+        assert_eq!(debug, "Token { len: 47 }");
+        for segment in token.as_ref().split('.') {
+            assert!(!debug.contains(segment));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Context
`JwtSvid` derived `Debug` through an internal `Token` wrapper that printed the full compact JWT. Logging or formatting an SVID with `{:?}` could leak a bearer token (including the signature), which conflicts with the crate’s existing secret-handling practice for `PrivateKey`.

## Changes
- Replace derived `Debug` on `Token` with a length-only implementation (`Token { len: N }`), matching `PrivateKey`.
- Document that the compact JWT is omitted from `JwtSvid` `Debug` output.
- Add unit tests covering `JwtSvid` and `Token` Debug redaction.
- Record the change under Unreleased in `spiffe/CHANGELOG.md`.

## Security
- Advisory: none
- Fix: `Debug` no longer emits the compact JWT bearer token for `JwtSvid` / `Token`.

## Compatibility
- MSRV: unchanged
- Breaking changes: none (Debug formatting of JWT-SVIDs changes; `Debug` is not a stable API contract)
- Affected crates/features: `spiffe` with `jwt`

## Testing
Covered by CI. Locally: `cargo test -p spiffe --features jwt --lib redacts`

## Release notes
- **JwtSvid:** `Debug` no longer includes the compact JWT token; only the token length is shown (matching `PrivateKey` redaction).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxlambrecht/rust-spiffe/380)
<!-- Reviewable:end -->
