### PR TITLE
fix(workload-api): reject empty mandatory X509SVID.bundle fields

### DIFF
--- a/spiffe/CHANGELOG.md
+++ b/spiffe/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **WorkloadApiClient / X509Source:** Reject `FetchX509SVID` responses whose mandatory per-SVID `bundle` field is empty, reporting `WorkloadApiError::MissingRequiredField` instead of accepting malformed identity material. Initial `X509Source` synchronization fails cleanly, while steady-state malformed updates retain the previous complete SVID and bundle snapshot without notifying subscribers. Empty standalone and federated X.509 bundles remain valid for bundle revocation.
+
 ## [0.16.1] - 2026-08-08
 
 ### Fixed

--- a/spiffe/src/workload_api/client/x509.rs
+++ b/spiffe/src/workload_api/client/x509.rs
@@ -180,6 +180,8 @@ impl WorkloadApiClient {
     fn parse_x509_svid_from_grpc_response(
         response: &X509svidResponse,
     ) -> Result<X509Svid, WorkloadApiError> {
+        Self::validate_required_x509_svid_fields(response)?;
+
         let svid = response
             .svids
             .get(DEFAULT_SVID)
@@ -196,6 +198,8 @@ impl WorkloadApiClient {
     fn parse_x509_svids_from_grpc_response(
         response: &X509svidResponse,
     ) -> Result<Vec<X509Svid>, WorkloadApiError> {
+        Self::validate_required_x509_svid_fields(response)?;
+
         response
             .svids
             .iter()
@@ -236,6 +240,8 @@ impl WorkloadApiClient {
     fn parse_x509_context_from_grpc_response(
         response: X509svidResponse,
     ) -> Result<X509Context, WorkloadApiError> {
+        Self::validate_required_x509_svid_fields(&response)?;
+
         let mut svids: Vec<Arc<X509Svid>> = Vec::new();
         let mut bundle_set = X509BundleSet::new();
 
@@ -268,5 +274,106 @@ impl WorkloadApiClient {
         }
 
         Ok(X509Context::new(svids, Arc::new(bundle_set)))
+    }
+
+    fn validate_required_x509_svid_fields(
+        response: &X509svidResponse,
+    ) -> Result<(), WorkloadApiError> {
+        if response.svids.iter().any(|svid| svid.bundle.is_empty()) {
+            return Err(WorkloadApiError::MissingRequiredField {
+                field: "X509SVID.bundle",
+            });
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workload_api::pb::workload::X509svid;
+    use std::collections::HashMap;
+
+    fn x509_svid(bundle: &[u8]) -> X509svid {
+        let cert = include_bytes!("../../../tests/testdata/svid/x509/1-svid-chain.der");
+        let key = include_bytes!("../../../tests/testdata/svid/x509/1-key.der");
+        X509svid {
+            spiffe_id: "spiffe://example.org/workload".into(),
+            x509_svid: cert.to_vec().into(),
+            x509_svid_key: key.to_vec().into(),
+            bundle: bundle.to_vec().into(),
+            hint: String::new(),
+        }
+    }
+
+    fn assert_missing_required_local_bundle<T>(result: &Result<T, WorkloadApiError>) {
+        assert!(matches!(
+            result,
+            Err(WorkloadApiError::MissingRequiredField {
+                field: "X509SVID.bundle"
+            })
+        ));
+    }
+
+    #[test]
+    fn x509_context_rejects_empty_required_local_bundle() {
+        let response = X509svidResponse {
+            svids: vec![x509_svid(&[])],
+            ..X509svidResponse::default()
+        };
+
+        let result = WorkloadApiClient::parse_x509_context_from_grpc_response(response);
+
+        assert_missing_required_local_bundle(&result);
+    }
+
+    #[test]
+    fn default_x509_svid_parser_rejects_empty_required_bundle_in_complete_response() {
+        let bundle = include_bytes!("../../../tests/testdata/bundle/x509/cert1.der");
+        let response = X509svidResponse {
+            // Even though the selected default entry is valid, a malformed later entry
+            // makes the complete Workload API response invalid and must discard it.
+            svids: vec![x509_svid(bundle), x509_svid(&[])],
+            ..X509svidResponse::default()
+        };
+
+        let result = WorkloadApiClient::parse_x509_svid_from_grpc_response(&response);
+
+        assert_missing_required_local_bundle(&result);
+    }
+
+    #[test]
+    fn all_x509_svids_parser_rejects_empty_required_local_bundle() {
+        let response = X509svidResponse {
+            svids: vec![x509_svid(&[])],
+            ..X509svidResponse::default()
+        };
+
+        let result = WorkloadApiClient::parse_x509_svids_from_grpc_response(&response);
+
+        assert_missing_required_local_bundle(&result);
+    }
+
+    #[test]
+    fn x509_context_accepts_empty_optional_federated_bundle() {
+        let local_bundle = include_bytes!("../../../tests/testdata/bundle/x509/cert1.der");
+        let federated_trust_domain = TrustDomain::new("federated.example.org").unwrap();
+        let response = X509svidResponse {
+            svids: vec![x509_svid(local_bundle)],
+            federated_bundles: HashMap::from([(
+                federated_trust_domain.to_string(),
+                Vec::new().into(),
+            )]),
+            ..X509svidResponse::default()
+        };
+
+        let context = WorkloadApiClient::parse_x509_context_from_grpc_response(response).unwrap();
+        let bundle = context
+            .bundle_set()
+            .get(&federated_trust_domain)
+            .expect("empty federated bundle should remain present in the complete update");
+
+        assert!(bundle.authorities().is_empty());
     }
 }

--- a/spiffe/src/workload_api/error.rs
+++ b/spiffe/src/workload_api/error.rs
@@ -38,6 +38,16 @@ pub enum WorkloadApiError {
     #[error("empty Workload API response")]
     EmptyResponse,
 
+    /// The Workload API response omitted a field required by the SPIFFE Workload API.
+    ///
+    /// This indicates malformed response material from a non-conforming Workload API
+    /// implementation, not a transport failure.
+    #[error("Workload API response is missing required field: {field}")]
+    MissingRequiredField {
+        /// The protocol field that was absent or empty.
+        field: &'static str,
+    },
+
     /// Failed to parse the Workload API endpoint string.
     #[error("invalid workload api endpoint: {0}")]
     Endpoint(#[from] EndpointError),
@@ -106,6 +116,16 @@ impl WorkloadApiError {
             Self::Transport(TransportError::Status(status))
                 if status.code() == tonic::Code::InvalidArgument
         )
+    }
+
+    /// Returns `true` if the response itself violates the Workload API protocol.
+    ///
+    /// Retrying an initial synchronization cannot make deterministic malformed
+    /// response material valid, so sources use this classification to fail cleanly.
+    #[cfg(feature = "x509-source")]
+    #[must_use]
+    pub(crate) const fn is_malformed_response(&self) -> bool {
+        matches!(self, Self::MissingRequiredField { .. })
     }
 }
 

--- a/spiffe/src/x509_source/errors.rs
+++ b/spiffe/src/x509_source/errors.rs
@@ -11,11 +11,11 @@ pub enum X509SourceError {
     /// During the initial synchronization performed by [`X509Source::new`](crate::X509Source::new)/
     /// [`X509SourceBuilder::build`](crate::X509SourceBuilder::build), most underlying
     /// [`WorkloadApiError`]s (e.g. transient connectivity failures, `NoIdentityIssued`)
-    /// are retried with backoff rather than surfaced immediately. The one exception is a
-    /// gRPC `INVALID_ARGUMENT` response (see [`WorkloadApiError::is_invalid_argument`]):
-    /// since retrying would just repeat the same rejection, initial sync fails fast and
-    /// returns this error instead of retrying indefinitely. Steady-state reconnects after
-    /// a successful initial sync are unaffected and continue retrying as before.
+    /// are retried with backoff rather than surfaced immediately. Deterministic protocol
+    /// failures—either a gRPC `INVALID_ARGUMENT` response (see
+    /// [`WorkloadApiError::is_invalid_argument`]) or malformed response material—fail fast,
+    /// since retrying would just repeat the same failure. Steady-state reconnects after a
+    /// successful initial sync are unaffected and continue retrying as before.
     #[error("x509 source error: {0}")]
     Source(#[from] WorkloadApiError),
 

--- a/spiffe/src/x509_source/source.rs
+++ b/spiffe/src/x509_source/source.rs
@@ -234,6 +234,11 @@ impl Debug for Inner {
 }
 
 impl X509Source {
+    #[cfg(test)]
+    pub(super) const fn inner_for_test(&self) -> &Arc<Inner> {
+        &self.inner
+    }
+
     /// Creates an `X509Source` using the default Workload API endpoint.
     ///
     /// The endpoint is resolved from `SPIFFE_ENDPOINT_SOCKET`. The source selects the default

--- a/spiffe/src/x509_source/supervisor.rs
+++ b/spiffe/src/x509_source/supervisor.rs
@@ -203,10 +203,10 @@ pub(super) async fn initial_sync_with_retry(
                 // reconnects (after a successful initial sync) are intentionally left
                 // retrying as before, since we already hold valid material at that point.
                 if let X509SourceError::Source(inner) = &e {
-                    if inner.is_invalid_argument() {
+                    if inner.is_invalid_argument() || inner.is_malformed_response() {
                         warn!(
-                            "Initial sync: Workload API rejected the request as invalid \
-                             (INVALID_ARGUMENT); not retrying: error={e}"
+                            "Initial sync: Workload API request or response is deterministically \
+                             invalid; not retrying: error={e}"
                         );
                         return Err(e);
                     }
@@ -503,12 +503,24 @@ impl Inner {
 mod tests {
     use super::*;
     use crate::transport::TransportError;
+    use crate::{TrustDomain, X509Bundle, X509BundleSet, X509Source};
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     fn invalid_argument_error() -> WorkloadApiError {
         WorkloadApiError::Transport(TransportError::Status(tonic::Status::invalid_argument(
             "bad request",
         )))
+    }
+
+    fn context_with_bundle(authority: &[u8]) -> Arc<X509Context> {
+        let cert = include_bytes!("../../tests/testdata/svid/x509/1-svid-chain.der");
+        let key = include_bytes!("../../tests/testdata/svid/x509/1-key.der");
+        let svid = Arc::new(X509Svid::parse_from_der(cert, key).unwrap());
+        let trust_domain = TrustDomain::new("example.org").unwrap();
+        let bundle = X509Bundle::from_x509_authorities(trust_domain, &[authority]).unwrap();
+        let mut bundle_set = X509BundleSet::new();
+        bundle_set.add_bundle(bundle);
+        Arc::new(X509Context::new([svid], Arc::new(bundle_set)))
     }
 
     #[tokio::test]
@@ -556,5 +568,82 @@ mod tests {
             1,
             "must not retry client creation after an INVALID_ARGUMENT response"
         );
+    }
+
+    #[tokio::test]
+    async fn initial_sync_fails_fast_on_malformed_response() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let attempts_clone = Arc::clone(&attempts);
+        let make_client: ClientFactory = Arc::new(move || {
+            attempts_clone.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async {
+                Err(WorkloadApiError::MissingRequiredField {
+                    field: "X509SVID.bundle",
+                })
+            })
+        });
+        let cancel = CancellationToken::new();
+        let reconnect = ReconnectConfig::new(Duration::from_secs(30), Duration::from_secs(60));
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(500),
+            initial_sync_with_retry(
+                &make_client,
+                None,
+                &cancel,
+                reconnect,
+                ResourceLimits::default(),
+                None,
+            ),
+        )
+        .await
+        .expect("initial sync should fail fast on malformed response material");
+
+        assert!(matches!(
+            result,
+            Err(X509SourceError::Source(
+                WorkloadApiError::MissingRequiredField {
+                    field: "X509SVID.bundle"
+                }
+            ))
+        ));
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn malformed_update_retains_snapshot_without_notification_and_next_update_recovers() {
+        let old_authority = include_bytes!("../../tests/testdata/bundle/x509/cert1.der");
+        let new_authority = include_bytes!("../../tests/testdata/bundle/x509/cert2.der");
+        let initial = context_with_bundle(old_authority);
+        let recovered = context_with_bundle(new_authority);
+        let source = X509Source::new_for_test(
+            Arc::clone(&initial),
+            ReconnectConfig::default(),
+            ResourceLimits::default(),
+            None,
+            None,
+        );
+        let cancel = CancellationToken::new();
+
+        let mut malformed_stream =
+            futures::stream::iter([Err(WorkloadApiError::MissingRequiredField {
+                field: "X509SVID.bundle",
+            })]);
+        source
+            .inner_for_test()
+            .process_stream_updates(&mut malformed_stream, &cancel, 1)
+            .await;
+
+        assert_eq!(source.x509_context().unwrap().as_ref(), initial.as_ref());
+        assert_eq!(source.updated().last(), 0);
+
+        let mut recovered_stream = futures::stream::iter([Ok(recovered.as_ref().clone())]);
+        source
+            .inner_for_test()
+            .process_stream_updates(&mut recovered_stream, &cancel, 2)
+            .await;
+
+        assert_eq!(source.x509_context().unwrap().as_ref(), recovered.as_ref());
+        assert_eq!(source.updated().last(), 1);
     }
 }

--- a/spiffe/tests/x509_bundle.rs
+++ b/spiffe/tests/x509_bundle.rs
@@ -22,6 +22,15 @@ mod x509_bundle_tests {
     }
 
     #[test]
+    fn test_x509_bundle_parse_from_empty_der_preserves_revocation_semantics() {
+        let trust_domain = TrustDomain::new("domain.test").unwrap();
+
+        let bundle = X509Bundle::parse_from_der(trust_domain, &[]).unwrap();
+
+        assert!(bundle.authorities().is_empty());
+    }
+
+    #[test]
     fn test_x509_bundle_parse_from_authorities() {
         let authority1: &[u8] = include_bytes!("testdata/bundle/x509/cert1.der");
         let authority2: &[u8] = include_bytes!("testdata/bundle/x509/cert2.der");


### PR DESCRIPTION
## Context
`FetchX509SVID` responses with an empty mandatory per-SVID `bundle` field were accepted and could replace a valid `X509Source` snapshot with empty local trust material. Workload API §4.5 says clients SHOULD error and discard messages where a mandatory field has its default value.

## Changes
- Reject empty `X509SVID.bundle` at all FetchX509SVID parse boundaries via `WorkloadApiError::MissingRequiredField`
- Validate the complete response before accepting any SVID entry
- Fail fast on malformed material during initial `X509Source` sync
- Retain the previous SVID/bundle snapshot (no update notification) for steady-state malformed updates; recover on the next valid update
- Preserve empty standalone and federated X.509 bundles for revocation semantics
- Add focused unit/source tests and an Unreleased changelog entry

## Security
- Advisory: none
- Fix: malformed empty local bundles no longer wipe a previously installed trust snapshot; empty federated/standalone bundles remain valid revocation signals

## Compatibility
- MSRV: unchanged
- Breaking changes: none for conforming servers; non-conforming empty `X509SVID.bundle` now returns `MissingRequiredField` (`#[non_exhaustive]` variant) instead of an empty local bundle
- Affected crates/features: `spiffe` (`workload-api-x509`, `x509-source`)

## Testing
Covered by unit tests for all FetchX509SVID parsers (including complete-response discard), empty federated acceptance, standalone empty-bundle revocation, initial-sync fail-fast, and steady-state retain/recover. `cargo fmt`, `clippy -D warnings`, and focused `cargo test` for these paths pass.

## Release notes
- **WorkloadApiClient / X509Source:** Reject `FetchX509SVID` responses whose mandatory per-SVID `bundle` field is empty, reporting `WorkloadApiError::MissingRequiredField` instead of accepting malformed identity material. Initial `X509Source` synchronization fails cleanly, while steady-state malformed updates retain the previous complete SVID and bundle snapshot without notifying subscribers. Empty standalone and federated X.509 bundles remain valid for bundle revocation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxlambrecht/rust-spiffe/383)
<!-- Reviewable:end -->
