### PR TITLE
docs(jwt): clarify JWKS use filtering and kid requirement

### DIFF
--- a/spiffe/CHANGELOG.md
+++ b/spiffe/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Documentation
+
+- **JWT bundles / JWT-SVID:** Clarified that Workload API JWT JWKS entries may omit `use`, and documented the deliberate fail-closed requirement for JWT-SVID `kid` headers, including interoperability implications for non-SPIRE issuers.
+
 ## [0.16.1] - 2026-08-08
 
 ### Fixed

--- a/spiffe/src/bundle/jwt/mod.rs
+++ b/spiffe/src/bundle/jwt/mod.rs
@@ -123,8 +123,15 @@ impl JwtBundle {
         &self.trust_domain
     }
 
-    /// Parses a `JwtBundle` from bytes representing a set of  JWT authorities. The data must be
-    /// a standard RFC 7517 JWTK document.
+    /// Parses a `JwtBundle` from an RFC 7517 JWK Set containing JWT authorities.
+    ///
+    /// This consumes the purpose-specific JWKS returned by the Workload API
+    /// `FetchJWTBundles` RPC, not a full SPIFFE bundle document. The Workload API
+    /// has already selected JWT-SVID signing keys, and standard JWKS entries may
+    /// omit the SPIFFE bundle-document `use` field. Consequently, this method does
+    /// not filter authorities by `use == "jwt-svid"`. Callers starting with a full
+    /// SPIFFE bundle document must perform that purpose filtering before calling
+    /// this method.
     ///
     /// # Arguments
     ///
@@ -416,7 +423,7 @@ mod jwt_bundle_test {
     }
 
     #[test]
-    fn test_parse_bundle_from_json_single_authority() {
+    fn test_parse_workload_api_jwks_keeps_authority_without_use() {
         let bundle_bytes = r#"{
             "keys": [
                 {
@@ -433,9 +440,11 @@ mod jwt_bundle_test {
         let trust_domain = td("example.org");
         let jwt_bundle = JwtBundle::from_jwt_authorities(trust_domain, bundle_bytes).unwrap();
 
-        assert!(jwt_bundle
+        let authority = jwt_bundle
             .find_jwt_authority("C6vs25welZOx6WksNYfbMfiw9l96pMnD")
-            .is_some());
+            .expect("authority without 'use' must remain selectable");
+        let jwk: Value = serde_json::from_slice(authority.jwk_json()).unwrap();
+        assert!(jwk.get("use").is_none());
     }
 
     #[test]

--- a/spiffe/src/svid/jwt/mod.rs
+++ b/spiffe/src/svid/jwt/mod.rs
@@ -6,6 +6,15 @@
 //! 2) **Offline verification**: verify a token using JWT authorities from bundles.
 //!    Requires a JWT verification backend feature (`jwt-verify-rust-crypto` or `jwt-verify-aws-lc-rs`)
 //!    and [`JwtSvid::parse_and_validate`].
+//!
+//! ## `kid` compatibility constraint
+//!
+//! Although the JWT-SVID specification makes the `kid` header optional, this
+//! implementation deliberately requires it. Key selection and the public
+//! [`JwtSvid::key_id`] API are `kid`-based; rejecting tokens without one is a
+//! fail-closed policy that matches SPIRE-issued JWT-SVIDs and existing ecosystem
+//! behavior. JWT-SVIDs from non-SPIRE issuers that omit `kid` are therefore
+//! rejected, even if they otherwise satisfy the JWT-SVID profile.
 
 use std::fmt;
 use std::marker::PhantomData;


### PR DESCRIPTION
## Context
Document two deliberate JWT compatibility constraints that came up in review: Workload API JWKS input for `JwtBundle::from_jwt_authorities` (no `use` filtering), and the fail-closed `kid` requirement for JWT-SVID parsing.

## Changes
- Clarify that `JwtBundle::from_jwt_authorities` consumes purpose-specific Workload API JWKS, not a full SPIFFE bundle document, and intentionally does not filter on `use == "jwt-svid"`.
- Document the deliberate fail-closed `kid` requirement and its impact on non-SPIRE issuers that omit `kid`.
- Strengthen the regression test to assert an authority without `use` remains selectable.

## Security
- Advisory: none
- Fix: no behavior change; documents existing fail-closed `kid` policy and JWKS purpose contract

## Compatibility
- MSRV: unchanged
- Breaking changes: none
- Affected crates/features: `spiffe` (`jwt`, `jwt-verify-*`); docs and tests only

## Testing
Covered by focused unit tests:
- `cargo test -p spiffe --lib bundle::jwt:: --features jwt` (15 passed)
- `cargo test -p spiffe --lib svid::jwt:: --features jwt` (11 passed)
- `cargo test -p spiffe --lib svid::jwt:: --features jwt-verify-rust-crypto` (22 passed, including missing-`kid` rejection)

## Release notes
- Clarified JWT bundle JWKS input contract and intentional JWT-SVID `kid` requirement (docs only; no behavior change).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maxlambrecht/rust-spiffe/385)
<!-- Reviewable:end -->
